### PR TITLE
wasi: raise a trap on out-of-range memory access

### DIFF
--- a/lib/wasi.c
+++ b/lib/wasi.c
@@ -2270,7 +2270,7 @@ fail:
                 HOST_FUNC_RESULT_SET(ft, results, 0, i32,
                                      wasi_convert_errno(ret));
         }
-        return 0;
+        return host_ret;
 }
 
 static int
@@ -2314,7 +2314,7 @@ fail:
                 HOST_FUNC_RESULT_SET(ft, results, 0, i32,
                                      wasi_convert_errno(ret));
         }
-        return 0;
+        return host_ret;
 }
 
 static int
@@ -2834,7 +2834,7 @@ fail:
                 HOST_FUNC_RESULT_SET(ft, results, 0, i32,
                                      wasi_convert_errno(ret));
         }
-        return 0;
+        return host_ret;
 }
 
 static int

--- a/lib/wasi.c
+++ b/lib/wasi.c
@@ -2160,6 +2160,7 @@ retry:
         assert(events + nevents == ev);
         uint32_t result = host_to_le32(nevents);
         host_ret = wasi_copyout(ctx, &result, retp, sizeof(result));
+        ret = 0;
 fail:
         for (i = 0; i < nfdinfos; i++) {
                 wasi_fdinfo_release(wasi, fdinfos[i]);


### PR DESCRIPTION
The previous logic was broken.
It was returning EFAULT (which indicating a trap in memory_getptr) to the caller without processing the trap properly.

This commit fixes it by distinguishing user-level error and host-level error. EFAULT for traps is a host-level error.

cf. https://github.com/WebAssembly/WASI/issues/505