### PR TITLE
a few linear memory related improvements

### DIFF
--- a/lib/exec.c
+++ b/lib/exec.c
@@ -115,8 +115,7 @@ do_trap:
                 if (ret != 0) {
                         return ret;
                 }
-                xlog_trace_insn("extend memory %" PRIu32 " from %" PRIu32
-                                " to %" PRIu32,
+                xlog_trace_insn("extend memory %" PRIu32 " from %zu to %zu",
                                 memidx, meminst->allocated, need);
                 if (movedp != NULL) {
                         *movedp = true;

--- a/lib/exec.c
+++ b/lib/exec.c
@@ -111,6 +111,7 @@ do_trap:
                 }
 #endif
                 size_t need = (size_t)last_byte + 1;
+                assert(need > meminst->allocated);
                 int ret = resize_array((void **)&meminst->data, need, 1);
                 if (ret != 0) {
                         return ret;
@@ -1416,7 +1417,12 @@ retry:
                          * Note: overflow check is already done in
                          * resize_array
                          */
-                        mi->allocated = (size_t)new_size * WASM_PAGE_SIZE;
+                        size_t new_allocated =
+                                (size_t)new_size * WASM_PAGE_SIZE;
+                        assert(new_allocated > mi->allocated);
+                        memset(mi->data + mi->allocated, 0,
+                               new_allocated - mi->allocated);
+                        mi->allocated = new_allocated;
                 }
 #if defined(TOYWASM_ENABLE_WASM_THREADS)
                 if (shared && c != NULL) {

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -183,7 +183,7 @@ memory_instance_create(struct meminst **mip,
                 uint32_t need_in_pages = mt->lim.min;
 #endif /* defined(TOYWASM_PREALLOC_SHARED_MEMORY) */
                 uint64_t need_in_bytes = need_in_pages * WASM_PAGE_SIZE;
-                if (need_in_bytes > UINT32_MAX) {
+                if (need_in_bytes > SIZE_MAX) {
                         free(mp);
                         ret = EOVERFLOW;
                         goto fail;
@@ -194,12 +194,14 @@ memory_instance_create(struct meminst **mip,
                         ret = ENOMEM;
                         goto fail;
                 }
-                mp->data = zalloc(need_in_bytes);
-                if (mp->data == NULL) {
-                        free(mp->shared);
-                        free(mp);
-                        ret = ENOMEM;
-                        goto fail;
+                if (need_in_bytes > 0) {
+                        mp->data = zalloc(need_in_bytes);
+                        if (mp->data == NULL) {
+                                free(mp->shared);
+                                free(mp);
+                                ret = ENOMEM;
+                                goto fail;
+                        }
                 }
                 mp->allocated = need_in_bytes;
                 waiter_list_table_init(&mp->shared->tab);

--- a/lib/type.h
+++ b/lib/type.h
@@ -378,7 +378,7 @@ struct meminst {
         uint8_t *data;
         /* Note: memory_getptr2 reads size_in_pages w/o locks */
         _Atomic uint32_t size_in_pages; /* overrides type->min */
-        uint32_t allocated;
+        size_t allocated;
         const struct memtype *type;
 
 #if defined(TOYWASM_ENABLE_WASM_THREADS)

--- a/wat/large_memory.wat.in
+++ b/wat/large_memory.wat.in
@@ -1,0 +1,54 @@
+;; % m4 large_memory.wat.in | wat2wasm -o large_memory.wasm -
+;; % m4 -DSHARED large_memory.wat.in | wat2wasm --enable-threads -o large_shared_memory.wasm -
+
+define(STORE,
+    i32.const $1
+    i32.const $2
+    i32.store)
+
+define(CHECK,
+    i32.const $1
+    i32.load
+    i32.const $2
+    i32.ne
+    if
+      unreachable
+    end)
+
+(module
+  (func (export "_start")
+    i32.const 65536
+    memory.grow
+    i32.const -1
+    i32.eq
+    if
+      unreachable
+    end
+
+    i32.const 1
+    memory.grow  ;; should fail
+    i32.const -1
+    i32.ne
+    if
+      unreachable
+    end
+
+    CHECK(0x0000_0000, 0x0000_0000)
+    CHECK(0x8000_0000, 0x0000_0000)
+    CHECK(0xffff_fff0, 0x0000_0000)
+    CHECK(0xffff_fffc, 0x0000_0000)
+
+    STORE(0x0000_0000, 0xdead_beef)
+    STORE(0x8000_0000, 0xbadd_cafe)
+    STORE(0xffff_fff0, 0x9abc_def0)
+    STORE(0xffff_fffc, 0x1234_5678)
+
+    CHECK(0x0000_0000, 0xdead_beef)
+    CHECK(0x8000_0000, 0xbadd_cafe)
+    CHECK(0xffff_fff0, 0x9abc_def0)
+    CHECK(0xffff_fffc, 0x1234_5678)
+  )
+ifdef(`SHARED',
+  (memory (export "memory") 0 65536 shared),
+  (memory (export "memory") 0))
+)


### PR DESCRIPTION
* don't bother to defer allocation to acctual access for large linear memory. realloc overhead is more troublesome.

* lift an implementation limit and allow to use the full 32-bit linear memory.  (on 64-bit platforms)

* reduce the number of 64-bit arithmetics in the fast path.