### PR TITLE
reuse validation context among exprs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(lib_core_sources
 	"instance.c"
 	"leb128.c"
 	"list.c"
+	"load_context.c"
 	"module.c"
 	"nbio.c"
 	"options.c"

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -91,6 +91,7 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                 lctx->vctx = vctx;
         }
         ctx->validation = vctx;
+        ctx->exec = NULL;
 
         assert(lctx->module != NULL);
         vctx->report = &lctx->report;

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -104,23 +104,24 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
         vctx->ei = ei = &expr->ei;
         memset(ei, 0, sizeof(*ei));
 
-        vctx->nlocals = parameter_types->ntypes + nlocals;
-        ret = ARRAY_RESIZE(vctx->locals, vctx->nlocals);
+        uint32_t lsize = parameter_types->ntypes + nlocals;
+        ret = VEC_PREALLOC(vctx->locals, lsize);
         if (ret != 0) {
                 goto fail;
         }
         uint32_t i;
         for (i = 0; i < parameter_types->ntypes; i++) {
-                vctx->locals[i] = parameter_types->types[i];
+                VEC_ELEM(vctx->locals, i) = parameter_types->types[i];
         }
         const struct localchunk *ch = locals;
         for (i = 0; i < nlocals; i += ch->n, ch++) {
                 uint32_t j;
                 for (j = 0; j < ch->n; j++) {
-                        vctx->locals[parameter_types->ntypes + i + j] =
-                                ch->type;
+                        VEC_ELEM(vctx->locals,
+                                 parameter_types->ntypes + i + j) = ch->type;
                 }
         }
+        vctx->locals.lsize = lsize;
 
         expr->start = p;
 

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -89,8 +89,6 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                 }
                 validation_context_init(vctx);
                 lctx->vctx = vctx;
-        } else {
-                validation_context_reuse(vctx);
         }
         ctx->validation = vctx;
 
@@ -183,8 +181,10 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                    ", cells %" PRIu32,
                    expr->end - expr->start, ei->njumps * sizeof(*ei->jumps),
                    ei->maxlabels, ei->maxcells);
+        validation_context_reuse(vctx);
         return 0;
 fail:
+        validation_context_reuse(vctx);
         free(ei->jumps);
         return ret;
 }

--- a/lib/insn_impl_base.h
+++ b/lib/insn_impl_base.h
@@ -92,8 +92,8 @@ INSN_IMPL(local_get)
                 local_get(ectx, localidx, STACK, &csz);
                 STACK_ADJ(csz);
         } else if (VALIDATING) {
-                CHECK(localidx < VCTX->nlocals);
-                PUSH_VAL(VCTX->locals[localidx], c);
+                CHECK(localidx < VCTX->locals.lsize);
+                PUSH_VAL(VEC_ELEM(VCTX->locals, localidx), c);
         }
         SAVE_PC;
         INSN_SUCCESS;
@@ -108,7 +108,7 @@ INSN_IMPL(local_set)
         LOAD_PC;
         READ_LEB_U32(localidx);
         if (VALIDATING) {
-                CHECK(localidx < VCTX->nlocals);
+                CHECK(localidx < VCTX->locals.lsize);
         }
         if (EXECUTING) {
                 struct exec_context *ectx = ECTX;
@@ -116,7 +116,7 @@ INSN_IMPL(local_set)
                 local_set(ectx, localidx, STACK, &csz);
                 STACK_ADJ(-(int32_t)csz);
         } else {
-                POP_VAL(VCTX->locals[localidx], a);
+                POP_VAL(VEC_ELEM(VCTX->locals, localidx), a);
         }
         SAVE_PC;
         INSN_SUCCESS;
@@ -131,15 +131,15 @@ INSN_IMPL(local_tee)
         LOAD_PC;
         READ_LEB_U32(localidx);
         if (VALIDATING) {
-                CHECK(localidx < VCTX->nlocals);
+                CHECK(localidx < VCTX->locals.lsize);
         }
         if (EXECUTING) {
                 struct exec_context *ectx = ECTX;
                 uint32_t csz;
                 local_set(ectx, localidx, STACK, &csz);
         } else {
-                POP_VAL(VCTX->locals[localidx], a);
-                PUSH_VAL(VCTX->locals[localidx], a);
+                POP_VAL(VEC_ELEM(VCTX->locals, localidx), a);
+                PUSH_VAL(VEC_ELEM(VCTX->locals, localidx), a);
         }
         SAVE_PC;
         INSN_SUCCESS;

--- a/lib/load_context.c
+++ b/lib/load_context.c
@@ -1,0 +1,24 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "context.h"
+#include "load_context.h"
+#include "validation.h"
+
+void
+load_context_init(struct load_context *ctx)
+{
+        memset(ctx, 0, sizeof(*ctx));
+        report_init(&ctx->report);
+        load_options_set_defaults(&ctx->options);
+}
+
+void
+load_context_clear(struct load_context *ctx)
+{
+        report_clear(&ctx->report);
+        bitmap_free(&ctx->refs);
+        validation_context_clear(ctx->vctx);
+        free(ctx->vctx);
+}

--- a/lib/load_context.c
+++ b/lib/load_context.c
@@ -19,6 +19,8 @@ load_context_clear(struct load_context *ctx)
 {
         report_clear(&ctx->report);
         bitmap_free(&ctx->refs);
-        validation_context_clear(ctx->vctx);
-        free(ctx->vctx);
+        if (ctx->vctx != NULL) {
+                validation_context_clear(ctx->vctx);
+                free(ctx->vctx);
+        }
 }

--- a/lib/load_context.h
+++ b/lib/load_context.h
@@ -12,6 +12,7 @@ struct load_context {
         bool has_datacount;
         uint32_t ndatas_in_datacount;
         struct load_options options;
+        struct validation_context *vctx;
 };
 
 void load_context_init(struct load_context *ctx);

--- a/lib/module.c
+++ b/lib/module.c
@@ -1814,21 +1814,6 @@ module_destroy(struct module *m)
         free(m);
 }
 
-void
-load_context_init(struct load_context *ctx)
-{
-        memset(ctx, 0, sizeof(*ctx));
-        report_init(&ctx->report);
-        load_options_set_defaults(&ctx->options);
-}
-
-void
-load_context_clear(struct load_context *ctx)
-{
-        report_clear(&ctx->report);
-        bitmap_free(&ctx->refs);
-}
-
 #if defined(TOYWASM_USE_RESULTTYPE_CELLIDX)
 static size_t
 resulttype_overhead(const struct resulttype *rt)

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -286,13 +286,20 @@ validation_context_init(struct validation_context *ctx)
 }
 
 void
-validation_context_clear(struct validation_context *ctx)
+validation_context_reuse(struct validation_context *ctx)
 {
         struct ctrlframe *cframe;
-
         VEC_FOREACH(cframe, ctx->cframes) {
                 ctrlframe_clear(cframe);
         }
+        ctx->cframes.lsize = 0;
+        ctx->valtypes.lsize = 0;
+}
+
+void
+validation_context_clear(struct validation_context *ctx)
+{
+        validation_context_reuse(ctx);
         VEC_FREE(ctx->cframes);
         VEC_FREE(ctx->valtypes);
         free(ctx->locals);

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -294,6 +294,7 @@ validation_context_reuse(struct validation_context *ctx)
         }
         ctx->cframes.lsize = 0;
         ctx->valtypes.lsize = 0;
+        ctx->ncells = 0;
 }
 
 void

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -295,6 +295,7 @@ validation_context_reuse(struct validation_context *ctx)
         ctx->cframes.lsize = 0;
         ctx->valtypes.lsize = 0;
         ctx->ncells = 0;
+        ctx->locals.lsize = 0;
 }
 
 void
@@ -303,7 +304,7 @@ validation_context_clear(struct validation_context *ctx)
         validation_context_reuse(ctx);
         VEC_FREE(ctx->cframes);
         VEC_FREE(ctx->valtypes);
-        free(ctx->locals);
+        VEC_FREE(ctx->locals);
 }
 
 void

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -25,8 +25,7 @@ struct validation_context {
         struct module *module;
         struct expr_exec_info *ei;
 
-        uint32_t nlocals;
-        enum valtype *locals;
+        VEC(, enum valtype) locals;
 
         bool const_expr;
 

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -80,6 +80,7 @@ int validation_failure(struct validation_context *ctx, const char *fmt, ...)
         __attribute__((__format__(__printf__, 2, 3)));
 struct resulttype *returntype(struct validation_context *ctx);
 void validation_context_init(struct validation_context *ctx);
+void validation_context_reuse(struct validation_context *ctx);
 void validation_context_clear(struct validation_context *ctx);
 void ctrlframe_clear(struct ctrlframe *cframe);
 int target_label_types(struct validation_context *ctx, uint32_t labelidx,


### PR DESCRIPTION
this makes some differences for huge modules.
(eg. ffmpeg.wasm has 14294 functions)

without this change:
```
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.18s s 0.01s e 0.20s maj 0 min 8156 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.18s s 0.01s e 0.20s maj 0 min 8162 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.18s s 0.01s e 0.19s maj 0 min 8373 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.17s s 0.01s e 0.18s maj 0 min 8056 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.18s s 0.01s e 0.19s maj 0 min 8423 in 0 out 0
```

with this change:
```
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.16s s 0.01s e 0.17s maj 0 min 8120 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.16s s 0.01s e 0.17s maj 0 min 8355 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.16s s 0.01s e 0.17s maj 0 min 8048 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.18s s 0.01s e 0.19s maj 0 min 8185 in 0 out 0
spacetanuki% time ./toywasm --wasi --load ../ffmpeg.wasm
u 0.17s s 0.01s e 0.18s maj 0 min 8126 in 0 out 0
spacetanuki%
```