### PR TITLE
remove unused jump table entries

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -175,6 +175,28 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                                 i, j->pc, j->targetpc);
         }
 #endif
+        if (vctx->can_shrink_jump_table) {
+                assert(ei->jumps != NULL);
+                assert(ei->njumps > 0);
+                const struct jump *from = ei->jumps;
+                struct jump *to = ei->jumps;
+                const struct jump *ep = ei->jumps + ei->njumps;
+                while (from < ep) {
+                        if (from->targetpc != JUMP_TABLE_INVALID_PC) {
+                                *to++ = *from;
+                        }
+                        from++;
+                }
+                assert(to < from);
+                xlog_trace("jump table shrinked from %" PRIu32 " to %zu",
+                           ei->njumps, to - ei->jumps);
+                ei->njumps = to - ei->jumps;
+                ret = resize_array((void **)&ei->jumps, sizeof(*ei->jumps),
+                                   ei->njumps);
+                if (ret != 0) {
+                        xlog_error("ignoring jump table resize failure");
+                }
+        }
         *pp = p;
 #if defined(TOYWASM_ENABLE_WRITER)
         expr->end = p;

--- a/lib/type.h
+++ b/lib/type.h
@@ -17,9 +17,11 @@
 #define WASM_PAGE_SIZE 65536
 #define WASM_MAX_PAGES 65536
 
+#define JUMP_TABLE_INVALID_PC 0xffffffff
+
 struct jump {
-        uint32_t pc;
-        uint32_t targetpc;
+        uint32_t pc; /* the address of block instruction (eg. block, loop) */
+        uint32_t targetpc; /* the jump target addreass */
 };
 
 struct type_annotation {

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -11,6 +11,7 @@ struct ctrlframe {
         uint32_t height;
         uint32_t height_cell;
         bool unreachable;
+        bool seen;
 };
 
 struct validation_context {
@@ -28,6 +29,7 @@ struct validation_context {
         VEC(, enum valtype) locals;
 
         bool const_expr;
+        bool can_shrink_jump_table;
 
         bool has_datacount;
         uint32_t ndatas_in_datacount;


### PR DESCRIPTION
some modules have redundant blocks for some reasons. this commit removes jump table entries for them.