### PR TITLE
add a test to run js.wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,18 +146,26 @@ add_test(NAME toywasm-cli-wasmtime-wasi-tests
 set_tests_properties(toywasm-cli-wasmtime-wasi-tests PROPERTIES ENVIRONMENT "${TEST_ENV}")
 set_tests_properties(toywasm-cli-wasmtime-wasi-tests PROPERTIES LABELS "wasmtime-wasi-tests")
 
+add_test(NAME toywasm-cli-js-wasm
+	COMMAND ./test/js-wasm.sh test/pi2.js
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(toywasm-cli-js-wasm PROPERTIES ENVIRONMENT "${TEST_ENV};TEST_RUNTIME_EXE=${TOYWASM_CLI} --wasi --wasi-dir=test --")
+set_tests_properties(toywasm-cli-js-wasm PROPERTIES LABELS "app")
+
 add_test(NAME toywasm-cli-spidermonkey
 	COMMAND ./test/run-spidermonkey.sh ${TOYWASM_CLI} --wasi
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 set_tests_properties(toywasm-cli-spidermonkey PROPERTIES ENVIRONMENT "${TEST_ENV}")
+set_tests_properties(toywasm-cli-spidermonkey PROPERTIES LABELS "app")
 
 add_test(NAME toywasm-cli-ffmpeg
 	COMMAND ./test/run-ffmpeg.sh ${TOYWASM_CLI} --wasi --wasi-dir=.video --
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 set_tests_properties(toywasm-cli-ffmpeg PROPERTIES ENVIRONMENT "${TEST_ENV}")
-set_tests_properties(toywasm-cli-ffmpeg PROPERTIES LABELS "slow")
+set_tests_properties(toywasm-cli-ffmpeg PROPERTIES LABELS "slow;app")
 endif() # TOYWASM_ENABLE_WASI
 
 if(NOT TOYWASM_ENABLE_WASM_MULTI_MEMORY)


### PR DESCRIPTION
i'm a bit uncomfortable as this effectively makes our ci to rely on mozilla's ci artifact. but i guess it practically isn't a problem.