### PR TITLE
check_interrupt: add a branch hint

### DIFF
--- a/lib/exec.c
+++ b/lib/exec.c
@@ -940,7 +940,7 @@ check_interrupt(struct exec_context *ctx)
          * theoretically we probably need a memory barrier.
          * practically it shouldn't be a problem though.
          */
-        if (ctx->intrp != NULL && *ctx->intrp != 0) {
+        if (ctx->intrp != NULL && __predict_false(*ctx->intrp != 0)) {
                 if (ctx->user_intr_delay_count < ctx->user_intr_delay) {
                         ctx->user_intr_delay_count++;
                 } else {


### PR DESCRIPTION
for some reasons this restores about 5% performance regression for test/run-ffmpeg.sh
(the regression was introduced by b112428647aa1427a159f8090e98fb3e2673e10e)

i'm not sure how this small change can affect the performance this much. especially when i've heard that recent processors don't use this simple pentium4 style "use jump directions as branch hints" prediction anymore. (here in my environment "2.2 GHz 6-Core Intel Core i7" is used)

without this
```
spacetanuki% ./test/run-ffmpeg.sh /usr/bin/time -l ./b/toywasm --wasi --wasi-dir=.video --
       83.77 real        83.71 user         0.04 sys
```
```
0000000100006e50 <_check_interrupt>:
100006e50: 48 8b 8f d0 00 00 00         movq    208(%rdi), %rcx
100006e57: 31 c0                        xorl    %eax, %eax
100006e59: 48 85 c9                     testq   %rcx, %rcx
100006e5c: 74 35                        je      0x100006e93 <_check_interrupt+0x43>
100006e5e: 8b 09                        movl    (%rcx), %ecx
100006e60: 85 c9                        testl   %ecx, %ecx
100006e62: 74 2f                        je      0x100006e93 <_check_interrupt+0x43>
100006e64: 8b 8f e0 00 00 00            movl    224(%rdi), %ecx
100006e6a: 3b 8f e4 00 00 00            cmpl    228(%rdi), %ecx
100006e70: 73 0a                        jae     0x100006e7c <_check_interrupt+0x2c>
100006e72: 83 c1 01                     addl    $1, %ecx
100006e75: 89 8f e0 00 00 00            movl    %ecx, 224(%rdi)
100006e7b: c3                           retq
100006e7c: c7 87 e0 00 00 00 00 00 00 00        movl    $0, 224(%rdi)
100006e86: 48 83 87 e8 01 00 00 01      addq    $1, 488(%rdi)
100006e8e: b8 fd ff ff ff               movl    $4294967293, %eax       ## imm = 0xFFFFFFFD
100006e93: c3                           retq
100006e94: 66 2e 0f 1f 84 00 00 00 00 00        nopw    %cs:(%rax,%rax)
100006e9e: 66 90                        nop
```

with this
```
spacetanuki% ./test/run-ffmpeg.sh /usr/bin/time -l ./b/toywasm --wasi --wasi-dir=.video --
       78.82 real        78.78 user         0.03 sys
```
```
0000000100006e20 <_check_interrupt>:
100006e20: 48 8b 8f d0 00 00 00         movq    208(%rdi), %rcx
100006e27: 31 c0                        xorl    %eax, %eax
100006e29: 48 85 c9                     testq   %rcx, %rcx
100006e2c: 74 06                        je      0x100006e34 <_check_interrupt+0x14>
100006e2e: 8b 09                        movl    (%rcx), %ecx
100006e30: 85 c9                        testl   %ecx, %ecx
100006e32: 75 01                        jne     0x100006e35 <_check_interrupt+0x15>
100006e34: c3                           retq
100006e35: 8b 8f e0 00 00 00            movl    224(%rdi), %ecx
100006e3b: 3b 8f e4 00 00 00            cmpl    228(%rdi), %ecx
100006e41: 73 0a                        jae     0x100006e4d <_check_interrupt+0x2d>
100006e43: 83 c1 01                     addl    $1, %ecx
100006e46: 89 8f e0 00 00 00            movl    %ecx, 224(%rdi)
100006e4c: c3                           retq
100006e4d: c7 87 e0 00 00 00 00 00 00 00        movl    $0, 224(%rdi)
100006e57: 48 83 87 e8 01 00 00 01      addq    $1, 488(%rdi)
100006e5f: b8 fd ff ff ff               movl    $4294967293, %eax       ## imm = 0xFFFFFFFD
100006e64: c3                           retq
100006e65: 66 2e 0f 1f 84 00 00 00 00 00        nopw    %cs:(%rax,%rax)
100006e6f: 90                           nop
```

references:

https://www.intel.com/content/dam/doc/manual/64-ia-32-architectures-optimization-manual.pdf Intel(R) 64 and IA-32 Architectures Optimization Reference Manual Order Number: 248966-026
April 2012
3.4.1.3 Static Prediction
> Pentium M, Intel Core Solo and Intel Core Duo processors do not
> statically predict conditional branches according to the jump direction.

https://xania.org/201602/bpu-part-two