### PR TITLE
retire trap()

### DIFF
--- a/lib/exec.c
+++ b/lib/exec.c
@@ -35,17 +35,6 @@ vtrap(struct exec_context *ctx, enum trapid id, const char *fmt, va_list ap)
 }
 
 int
-trap(struct exec_context *ctx, const char *fmt, ...)
-{
-        int ret;
-        va_list ap;
-        va_start(ap, fmt);
-        ret = vtrap(ctx, TRAP_MISC, fmt, ap);
-        va_end(ap);
-        return ret;
-}
-
-int
 trap_with_id(struct exec_context *ctx, enum trapid id, const char *fmt, ...)
 {
         int ret;

--- a/lib/exec.h
+++ b/lib/exec.h
@@ -59,8 +59,6 @@ int invoke(struct funcinst *finst, const struct resulttype *paramtype,
 
 int check_interrupt(struct exec_context *ctx);
 
-int trap(struct exec_context *ctx, const char *fmt, ...)
-        __attribute__((__format__(__printf__, 2, 3)));
 int trap_with_id(struct exec_context *ctx, enum trapid id, const char *fmt,
                  ...) __attribute__((__format__(__printf__, 3, 4)));
 int memory_getptr(struct exec_context *ctx, uint32_t memidx, uint32_t ptr,


### PR DESCRIPTION
everything uses trap_with_id these days.