### PR TITLE
CI: tries to fix cross jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,16 +358,6 @@ jobs:
         sudo apt-get update && sudo apt-get install -y clang-13 lld-13
         sudo ./cross/setup-alternatives.sh
 
-    # This list seems to use the PPA repo.
-    # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
-    # For some reasons, it interferes our scripts to install libcmocka for
-    # riscv64.
-    # https://github.com/yamt/toywasm/issues/80
-    - name: Remove ubuntu-toolchain-r-ubuntu-test-focal.list (cross)
-      if: matrix.os == 'ubuntu-20.04'
-      run: |
-        sudo rm /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-focal.list
-
     - name: Fix sources.list (cross)
       if: matrix.arch != 'native'
       run: |


### PR DESCRIPTION
The following runner image doesn't seem to have this file anymore.
```
  Image: ubuntu-20.04
  Version: 20240514.2.0
  Included Software: https://github.com/actions/runner-images/blob/ubuntu20/20240514.2/images/ubuntu/Ubuntu2004-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20240514.2
```