### PR TITLE
track heap usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ list(APPEND TEST_ENV "TEST_RUNTIME_EXE=${TOYWASM_CLI}")
 set(cli_sources
 	"cli/main.c"
 	"cli/repl.c"
+	"cli/str_to_uint.c"
 )
 
 add_executable(toywasm-cli ${cli_sources})

--- a/cli/main.c
+++ b/cli/main.c
@@ -36,6 +36,7 @@ enum longopt {
         opt_invoke,
         opt_load,
         opt_max_frames,
+        opt_max_memory,
         opt_max_stack_cells,
         opt_register,
         opt_repl,
@@ -126,6 +127,12 @@ static const struct option longopts[] = {
                 required_argument,
                 NULL,
                 opt_max_frames,
+        },
+        {
+                "max-memory",
+                required_argument,
+                NULL,
+                opt_max_memory,
         },
         {
                 "max-stack-cells",
@@ -228,6 +235,7 @@ static const char *opt_metavars[] = {
         [opt_repl_prompt] = "STRING",
         [opt_max_frames] = "NUMBER_OF_FRAMES",
         [opt_max_stack_cells] = "NUMBER_OF_CELLS",
+        [opt_max_memory] = "MEMORY_LIMIT_IN_BYTES",
 };
 
 static void
@@ -389,6 +397,12 @@ main(int argc, char *const *argv)
                 case opt_max_frames:
                         ret = str_to_u32(optarg, 0,
                                          &opts->exec_options.max_frames);
+                        if (ret != 0) {
+                                goto fail;
+                        }
+                        break;
+                case opt_max_memory:
+                        ret = str_to_size(optarg, 0, &mctx->limit);
                         if (ret != 0) {
                                 goto fail;
                         }

--- a/cli/main.c
+++ b/cli/main.c
@@ -9,6 +9,7 @@
 
 #include "mem.h"
 #include "repl.h"
+#include "str_to_uint.h"
 #include "toywasm_config.h"
 #if defined(TOYWASM_ENABLE_WASI_THREADS)
 #include "wasi_threads.h"
@@ -364,7 +365,11 @@ main(int argc, char *const *argv)
                         opts->dyld_options.paths = dyld_paths.p;
                         break;
                 case opt_dyld_stack_size:
-                        opts->dyld_options.stack_size = atoi(optarg);
+                        ret = str_to_u32(optarg, 0,
+                                         &opts->dyld_options.stack_size);
+                        if (ret != 0) {
+                                goto fail;
+                        }
                         break;
 #endif
                 case opt_invoke:
@@ -382,10 +387,18 @@ main(int argc, char *const *argv)
                         might_need_help = false;
                         break;
                 case opt_max_frames:
-                        opts->exec_options.max_frames = atoi(optarg);
+                        ret = str_to_u32(optarg, 0,
+                                         &opts->exec_options.max_frames);
+                        if (ret != 0) {
+                                goto fail;
+                        }
                         break;
                 case opt_max_stack_cells:
-                        opts->exec_options.max_stackcells = atoi(optarg);
+                        ret = str_to_u32(optarg, 0,
+                                         &opts->exec_options.max_stackcells);
+                        if (ret != 0) {
+                                goto fail;
+                        }
                         break;
                 case opt_register:
                         ret = toywasm_repl_register(state, NULL, optarg);

--- a/cli/main.c
+++ b/cli/main.c
@@ -332,6 +332,7 @@ main(int argc, char *const *argv)
         state->wasi_mctx = wasi_mctx;
         state->dyld_mctx = dyld_mctx;
         struct repl_options *opts = &state->opts;
+        size_t limit;
         while ((ret = getopt_long(argc, argv, "", longopts, &longidx)) != -1) {
                 switch (ret) {
                 case opt_disable_jump_table:
@@ -402,8 +403,15 @@ main(int argc, char *const *argv)
                         }
                         break;
                 case opt_max_memory:
-                        ret = str_to_size(optarg, 0, &mctx->limit);
+                        ret = str_to_size(optarg, 0, &limit);
                         if (ret != 0) {
+                                goto fail;
+                        }
+                        ret = mem_context_setlimit(mctx, limit);
+                        if (ret != 0) {
+                                xlog_error("failed to set limit %zu (current "
+                                           "allocation: %zu)",
+                                           limit, mctx->allocated);
                                 goto fail;
                         }
                         break;

--- a/cli/main.c
+++ b/cli/main.c
@@ -285,6 +285,7 @@ main(int argc, char *const *argv)
         struct mem_context mctx0, *mctx = &mctx0;
         struct mem_context wasi_mctx0, *wasi_mctx = &wasi_mctx0;
         struct mem_context dyld_mctx0, *dyld_mctx = &dyld_mctx0;
+        struct mem_context impobj_mctx0, *impobj_mctx = &impobj_mctx0;
 
         struct repl_state *state;
 #if defined(TOYWASM_ENABLE_WASI)
@@ -322,6 +323,10 @@ main(int argc, char *const *argv)
         mem_context_init(mctx);
         mem_context_init(wasi_mctx);
         mem_context_init(dyld_mctx);
+        mem_context_init(impobj_mctx);
+        wasi_mctx->parent = mctx;
+        dyld_mctx->parent = mctx;
+        impobj_mctx->parent = mctx;
 
         state = malloc(sizeof(*state));
         if (state == NULL) {
@@ -331,6 +336,7 @@ main(int argc, char *const *argv)
         state->mctx = mctx;
         state->wasi_mctx = wasi_mctx;
         state->dyld_mctx = dyld_mctx;
+        state->impobj_mctx = impobj_mctx;
         struct repl_options *opts = &state->opts;
         size_t limit;
         while ((ret = getopt_long(argc, argv, "", longopts, &longidx)) != -1) {

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -312,7 +312,7 @@ undo_wasi_create:
         wasi_instance_destroy(state->wasi);
         state->wasi = NULL;
 fail:
-        xlog_error("failed to load wasi");
+        xlog_error("failed to load wasi with error %u", ret);
         return ret;
 #endif
 }

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -207,6 +207,9 @@ toywasm_repl_reset(struct repl_state *state)
                 nbio_printf("wasi memory consumption immediately "
                             "before a reset: %zu\n",
                             state->wasi_mctx->allocated);
+                nbio_printf("dyld memory consumption immediately "
+                            "before a reset: %zu\n",
+                            state->dyld_mctx->allocated);
         }
         uint32_t n = 0;
         while (state->imports != NULL) {
@@ -265,6 +268,9 @@ toywasm_repl_reset(struct repl_state *state)
                 nbio_printf("wasi memory consumption immediately "
                             "after a reset: %zu\n",
                             state->wasi_mctx->allocated);
+                nbio_printf("dyld memory consumption immediately "
+                            "after a reset: %zu\n",
+                            state->dyld_mctx->allocated);
         }
 }
 
@@ -683,7 +689,7 @@ toywasm_repl_load(struct repl_state *state, const char *modname,
                         return ENOTSUP; /* not implemented */
                 }
                 struct dyld *d = &mod_u->u.dyld;
-                dyld_init(d);
+                dyld_init(d, state->dyld_mctx);
                 d->opts = state->opts.dyld_options;
                 d->opts.base_import_obj = state->imports;
                 ret = dyld_load(d, filename);
@@ -1136,6 +1142,7 @@ toywasm_repl_invoke(struct repl_state *state, const char *modname,
         if (state->opts.enable_dyld) {
                 struct dyld *d = &mod_u->u.dyld;
                 inst = dyld_main_object_instance(d);
+                mctx = state->mctx;
         } else
 #endif
         {

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -378,7 +378,7 @@ toywasm_repl_set_wasi_prestat_littlefs(struct repl_state *state,
                 return EPROTO;
         }
         int ret;
-        ret = VEC_PREALLOC(state->vfses, 1);
+        ret = VEC_PREALLOC(state->mctx, state->vfses, 1);
         if (ret != 0) {
                 return ret;
         }

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -178,22 +178,22 @@ repl_unload_u(struct repl_state *state, struct repl_module_state_u *mod_u)
         repl_unload(state, mod);
 }
 
+static void
+print_memory_usage(const struct mem_context *mctx, const char *label)
+{
+        nbio_printf("%23s %12zu\n", label, mctx->allocated);
+}
+
 void
 toywasm_repl_reset(struct repl_state *state)
 {
         if (state->opts.print_stats) {
-                nbio_printf("repl memory consumption immediately "
-                            "before a reset: %zu\n",
-                            state->mctx->allocated);
-                nbio_printf("wasi memory consumption immediately "
-                            "before a reset: %zu\n",
-                            state->wasi_mctx->allocated);
-                nbio_printf("dyld memory consumption immediately "
-                            "before a reset: %zu\n",
-                            state->dyld_mctx->allocated);
-                nbio_printf("impobj memory consumption immediately "
-                            "before a reset: %zu\n",
-                            state->impobj_mctx->allocated);
+                nbio_printf("=== memory consumption immediately before a repl "
+                            "reset ===\n");
+                print_memory_usage(state->mctx, "total");
+                print_memory_usage(state->wasi_mctx, "wasi");
+                print_memory_usage(state->dyld_mctx, "dyld");
+                print_memory_usage(state->impobj_mctx, "impobj");
         }
         uint32_t n = 0;
         while (state->imports != NULL) {
@@ -245,20 +245,6 @@ toywasm_repl_reset(struct repl_state *state)
         VEC_FREE(state->mctx, state->vfses);
 #endif
         assert(n == 0);
-        if (state->opts.print_stats) {
-                nbio_printf("repl memory consumption immediately "
-                            "after a reset: %zu\n",
-                            state->mctx->allocated);
-                nbio_printf("wasi memory consumption immediately "
-                            "after a reset: %zu\n",
-                            state->wasi_mctx->allocated);
-                nbio_printf("dyld memory consumption immediately "
-                            "after a reset: %zu\n",
-                            state->dyld_mctx->allocated);
-                nbio_printf("impobj memory consumption immediately "
-                            "after a reset: %zu\n",
-                            state->impobj_mctx->allocated);
-        }
 }
 
 int

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -32,6 +32,7 @@
 #include "nbio.h"
 #include "repl.h"
 #include "report.h"
+#include "str_to_uint.h"
 #include "suspend.h"
 #include "timeutil.h"
 #include "toywasm_version.h"
@@ -65,26 +66,6 @@
  * > under this type.
  */
 #define EXTERNREF_0 ((uintptr_t)(-1))
-
-int
-str_to_uint(const char *s, int base, uintmax_t *resultp)
-{
-        uintmax_t v;
-        char *ep;
-        errno = 0;
-        v = strtoumax(s, &ep, base);
-        if (s == ep) {
-                return EINVAL;
-        }
-        if (*ep != 0) {
-                return EINVAL;
-        }
-        if (errno != 0) {
-                return errno;
-        }
-        *resultp = v;
-        return 0;
-}
 
 int
 str_to_ptr(const char *s, int base, uintmax_t *resultp)

--- a/cli/repl.c
+++ b/cli/repl.c
@@ -598,6 +598,17 @@ repl_load_from_buf(struct repl_state *state, const char *modname,
                 return ENOTSUP;
         }
 #endif
+        struct mem_context *mctx2 =
+                mem_alloc(state->mctx, 2 * sizeof(struct mem_context));
+        if (mctx2 == NULL) {
+                return ENOMEM;
+        }
+        mod->module_mctx = mctx2;
+        mod->instance_mctx = mctx2 + 1;
+        mem_context_init(mod->module_mctx);
+        mem_context_init(mod->instance_mctx);
+        mod->module_mctx->parent = state->mctx;
+        mod->instance_mctx->parent = state->mctx;
         struct load_context ctx;
         load_context_init(&ctx, mod->module_mctx);
         ctx.options = state->opts.load_options;
@@ -702,17 +713,6 @@ toywasm_repl_load(struct repl_state *state, const char *modname,
 #endif
         struct repl_module_state *mod = &mod_u->u.repl;
         memset(mod, 0, sizeof(*mod));
-        struct mem_context *mctx2 =
-                mem_alloc(state->mctx, 2 * sizeof(struct mem_context));
-        if (mctx2 == NULL) {
-                return ENOMEM;
-        }
-        mod->module_mctx = mctx2;
-        mod->instance_mctx = mctx2 + 1;
-        mem_context_init(mod->module_mctx);
-        mem_context_init(mod->instance_mctx);
-        mod->module_mctx->parent = state->mctx;
-        mod->instance_mctx->parent = state->mctx;
         ret = map_file(filename, (void **)&mod->buf, &mod->bufsize);
         if (ret != 0) {
                 xlog_error("failed to map %s (error %d)", filename, ret);

--- a/cli/repl.h
+++ b/cli/repl.h
@@ -66,6 +66,7 @@ struct repl_state {
         struct mem_context *mctx;
         struct mem_context *wasi_mctx;
         struct mem_context *dyld_mctx;
+        struct mem_context *impobj_mctx;
 };
 
 void toywasm_repl_state_init(struct repl_state *state);

--- a/cli/repl.h
+++ b/cli/repl.h
@@ -29,6 +29,8 @@ struct repl_module_state {
 #if defined(TOYWASM_ENABLE_WASI_THREADS)
         struct import_object *extra_import;
 #endif
+        struct mem_context *module_mctx;
+        struct mem_context *instance_mctx;
 };
 
 struct repl_module_state_u {
@@ -49,20 +51,20 @@ struct registered_name {
 };
 
 struct repl_state {
-        struct repl_module_state_u *modules;
-        unsigned int nmodules;
+        VEC(, struct repl_module_state_u) modules;
         struct import_object *imports;
         unsigned int nregister;
         struct registered_name *registered_names;
-        struct val *param;
-        struct val *result;
+        VEC(, struct val) param;
+        VEC(, struct val) result;
         struct wasi_instance *wasi;
         struct wasi_threads_instance *wasi_threads;
-        unsigned int nvfses;
-        struct wasi_vfs **vfses;
+        VEC(, struct wasi_vfs *) vfses;
         struct repl_options opts;
         struct timespec abstimeout;
         bool has_timeout;
+        struct mem_context *mctx;
+        struct mem_context *wasi_mctx;
 };
 
 void toywasm_repl_state_init(struct repl_state *state);

--- a/cli/repl.h
+++ b/cli/repl.h
@@ -65,6 +65,7 @@ struct repl_state {
         bool has_timeout;
         struct mem_context *mctx;
         struct mem_context *wasi_mctx;
+        struct mem_context *dyld_mctx;
 };
 
 void toywasm_repl_state_init(struct repl_state *state);

--- a/cli/str_to_uint.c
+++ b/cli/str_to_uint.c
@@ -37,3 +37,18 @@ str_to_u32(const char *s, int base, uint32_t *resultp)
         *resultp = u;
         return 0;
 }
+
+int
+str_to_size(const char *s, int base, size_t *resultp)
+{
+        uintmax_t u;
+        int ret = str_to_uint(s, base, &u);
+        if (ret != 0) {
+                return ret;
+        }
+        if (u > SIZE_MAX) {
+                return EOVERFLOW;
+        }
+        *resultp = u;
+        return 0;
+}

--- a/cli/str_to_uint.c
+++ b/cli/str_to_uint.c
@@ -22,3 +22,18 @@ str_to_uint(const char *s, int base, uintmax_t *resultp)
         *resultp = v;
         return 0;
 }
+
+int
+str_to_u32(const char *s, int base, uint32_t *resultp)
+{
+        uintmax_t u;
+        int ret = str_to_uint(s, base, &u);
+        if (ret != 0) {
+                return ret;
+        }
+        if (u > UINT32_MAX) {
+                return EOVERFLOW;
+        }
+        *resultp = u;
+        return 0;
+}

--- a/cli/str_to_uint.c
+++ b/cli/str_to_uint.c
@@ -1,0 +1,24 @@
+#include <errno.h>
+#include <inttypes.h>
+
+#include "str_to_uint.h"
+
+int
+str_to_uint(const char *s, int base, uintmax_t *resultp)
+{
+        uintmax_t v;
+        char *ep;
+        errno = 0;
+        v = strtoumax(s, &ep, base);
+        if (s == ep) {
+                return EINVAL;
+        }
+        if (*ep != 0) {
+                return EINVAL;
+        }
+        if (errno != 0) {
+                return errno;
+        }
+        *resultp = v;
+        return 0;
+}

--- a/cli/str_to_uint.h
+++ b/cli/str_to_uint.h
@@ -1,4 +1,6 @@
+#include <stddef.h>
 #include <stdint.h>
 
 int str_to_uint(const char *s, int base, uintmax_t *resultp);
 int str_to_u32(const char *s, int base, uint32_t *resultp);
+int str_to_size(const char *s, int base, size_t *resultp);

--- a/cli/str_to_uint.h
+++ b/cli/str_to_uint.h
@@ -1,0 +1,3 @@
+#include <stdint.h>
+
+int str_to_uint(const char *s, int base, uintmax_t *resultp);

--- a/cli/str_to_uint.h
+++ b/cli/str_to_uint.h
@@ -1,3 +1,4 @@
 #include <stdint.h>
 
 int str_to_uint(const char *s, int base, uintmax_t *resultp);
+int str_to_u32(const char *s, int base, uint32_t *resultp);

--- a/examples/app/app.c
+++ b/examples/app/app.c
@@ -4,6 +4,7 @@
 
 #include <toywasm/fileio.h>
 #include <toywasm/load_context.h>
+#include <toywasm/mem.h>
 #include <toywasm/module.h>
 #include <toywasm/name.h>
 #include <toywasm/type.h>
@@ -12,6 +13,8 @@
 int
 main(int argc, char **argv)
 {
+        struct mem_context mctx;
+        mem_context_init(&mctx);
         if (argc != 2) {
                 xlog_error("unexpected number of args");
                 exit(2);
@@ -28,13 +31,14 @@ main(int argc, char **argv)
                 exit(1);
         }
         struct load_context ctx;
-        load_context_init(&ctx);
+        load_context_init(&ctx, &mctx);
         ret = module_create(&m, p, p + sz, &ctx);
         if (ret != 0) {
                 xlog_error("module_load failed with %d: %s", ret,
                            report_getmessage(&ctx.report));
                 exit(1);
         }
+        load_context_clear(&ctx);
         module_print_stats(m);
 
         /* perform some investigations on the loaded module */
@@ -163,6 +167,8 @@ main(int argc, char **argv)
         }
 #endif
         nametable_clear(&table);
+        module_destroy(&mctx, m);
+        mem_context_clear(&mctx);
 
         exit(0);
 }

--- a/examples/callgraph/main.c
+++ b/examples/callgraph/main.c
@@ -4,6 +4,7 @@
 
 #include <toywasm/fileio.h>
 #include <toywasm/load_context.h>
+#include <toywasm/mem.h>
 #include <toywasm/module.h>
 #include <toywasm/xlog.h>
 
@@ -26,14 +27,19 @@ main(int argc, char **argv)
                 xlog_error("map_file failed with %d", ret);
                 exit(1);
         }
+        struct mem_context mctx;
+        mem_context_init(&mctx);
         struct load_context ctx;
-        load_context_init(&ctx);
+        load_context_init(&ctx, &mctx);
         ret = module_create(&m, p, p + sz, &ctx);
         if (ret != 0) {
                 xlog_error("module_load failed with %d: %s", ret,
                            report_getmessage(&ctx.report));
                 exit(1);
         }
+        load_context_clear(&ctx);
         callgraph(m);
+        module_destroy(&mctx, m);
+        mem_context_clear(&mctx);
         exit(0);
 }

--- a/examples/fuzz/main.cxx
+++ b/examples/fuzz/main.cxx
@@ -12,6 +12,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
         struct mem_context mctx;
         mem_context_init(&mctx);
+        mctx.limit = 1 * 1024 * 1024;
         struct module *m;
         int ret;
         struct load_context ctx;

--- a/examples/fuzz/main.cxx
+++ b/examples/fuzz/main.cxx
@@ -3,16 +3,19 @@
 #include <toywasm/exec_context.h>
 #include <toywasm/instance.h>
 #include <toywasm/load_context.h>
+#include <toywasm/mem.h>
 #include <toywasm/module.h>
 #include <toywasm/report.h>
 
 extern "C" int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+        struct mem_context mctx;
+        mem_context_init(&mctx);
         struct module *m;
         int ret;
         struct load_context ctx;
-        load_context_init(&ctx);
+        load_context_init(&ctx, &mctx);
         ret = module_create(&m, data, data + size, &ctx);
         load_context_clear(&ctx);
         if (ret != 0) {
@@ -21,13 +24,13 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         struct instance *inst;
         struct report report;
         report_init(&report);
-        ret = instance_create_no_init(m, &inst, NULL, &report);
+        ret = instance_create_no_init(&mctx, m, &inst, NULL, &report);
         report_clear(&report);
         if (ret != 0) {
                 goto fail_instantiate;
         }
         struct exec_context ectx;
-        exec_context_init(&ectx, inst);
+        exec_context_init(&ectx, inst, &mctx);
         /* avoid infinite loops in the start function */
         const static atomic_uint one = 1;
         ectx.intrp = &one;
@@ -36,7 +39,8 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         exec_context_clear(&ectx);
         instance_destroy(inst);
 fail_instantiate:
-        module_destroy(m);
+        module_destroy(&mctx, m);
 fail_load:
+        mem_context_clear(&mctx);
         return 0;
 }

--- a/examples/hostfunc/hostfunc.c
+++ b/examples/hostfunc/hostfunc.c
@@ -244,9 +244,10 @@ static const struct host_module module_my_host_inst[] = {{
 }};
 
 int
-import_object_create_for_my_host_inst(void *inst, struct import_object **impp)
+import_object_create_for_my_host_inst(struct mem_context *mctx, void *inst,
+                                      struct import_object **impp)
 {
         return import_object_create_for_host_funcs(
-                module_my_host_inst, ARRAYCOUNT(module_my_host_inst), inst,
-                impp);
+                mctx, module_my_host_inst, ARRAYCOUNT(module_my_host_inst),
+                inst, impp);
 }

--- a/examples/hostfunc/hostfunc.h
+++ b/examples/hostfunc/hostfunc.h
@@ -1,4 +1,5 @@
+struct mem_context;
 struct import_object;
 
-int import_object_create_for_my_host_inst(void *inst,
+int import_object_create_for_my_host_inst(struct mem_context *mctx, void *inst,
                                           struct import_object **impp);

--- a/examples/log_execution/log_execution.c
+++ b/examples/log_execution/log_execution.c
@@ -47,9 +47,10 @@ static const struct host_module module_log_execution[] = {{
 }};
 
 int
-import_object_create_for_log_execution(void *inst, struct import_object **impp)
+import_object_create_for_log_execution(struct mem_context *mctx, void *inst,
+                                       struct import_object **impp)
 {
         return import_object_create_for_host_funcs(
-                module_log_execution, ARRAYCOUNT(module_log_execution), inst,
-                impp);
+                mctx, module_log_execution, ARRAYCOUNT(module_log_execution),
+                inst, impp);
 }

--- a/examples/log_execution/log_execution.h
+++ b/examples/log_execution/log_execution.h
@@ -1,4 +1,6 @@
 struct import_object;
+struct mem_context;
 
-int import_object_create_for_log_execution(void *inst,
+int import_object_create_for_log_execution(struct mem_context *mctx,
+                                           void *inst,
                                            struct import_object **impp);

--- a/examples/log_execution/main.c
+++ b/examples/log_execution/main.c
@@ -10,6 +10,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <toywasm/instance.h>
+#include <toywasm/mem.h>
 #include <toywasm/name.h>
 #include <toywasm/xlog.h>
 
@@ -38,15 +40,20 @@ main(int argc, char **argv)
         struct nametable table;
         nametable_init(&table);
 
+        struct mem_context mctx;
+        mem_context_init(&mctx);
         struct import_object *import_obj;
-        ret = import_object_create_for_log_execution(&table, &import_obj);
+        ret = import_object_create_for_log_execution(&mctx, &table,
+                                                     &import_obj);
         if (ret != 0) {
                 exit(1);
         }
-        ret = runwasi(a->filename, a->ndirs, a->dirs, a->nenvs,
+        ret = runwasi(&mctx, a->filename, a->ndirs, a->dirs, a->nenvs,
                       (const char *const *)a->envs, a->argc,
                       (const char *const *)a->argv, stdio_fds, import_obj,
                       &wasi_exit_code);
+        import_object_destroy(&mctx, import_obj);
+        mem_context_clear(&mctx);
         free(a->dirs);
         free(a->envs);
         nametable_clear(&table);

--- a/examples/runwasi/main.c
+++ b/examples/runwasi/main.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <toywasm/mem.h>
 #include <toywasm/xlog.h>
 
 #include "runwasi.h"
@@ -32,10 +33,13 @@ main(int argc, char **argv)
                 xlog_error("failed to process cli arguments");
                 exit(1);
         }
-        ret = runwasi(a->filename, a->ndirs, a->dirs, a->nenvs,
+        struct mem_context mctx;
+        mem_context_init(&mctx);
+        ret = runwasi(&mctx, a->filename, a->ndirs, a->dirs, a->nenvs,
                       (const char *const *)a->envs, a->argc,
                       (const char *const *)a->argv, stdio_fds, NULL,
                       &wasi_exit_code);
+        mem_context_clear(&mctx);
         free(a->dirs);
         free(a->envs);
         if (ret != 0) {

--- a/examples/runwasi/runwasi.h
+++ b/examples/runwasi/runwasi.h
@@ -1,8 +1,9 @@
 #include <stdint.h>
 
+struct mem_context;
 struct import_object;
 
-int runwasi(const char *filename, unsigned int ndirs, char **dirs,
-            unsigned int nenvs, const char *const *envs, int argc,
+int runwasi(struct mem_context *mctx, const char *filename, unsigned int ndirs,
+            char **dirs, unsigned int nenvs, const char *const *envs, int argc,
             const char *const *argv, const int stdio_fds[3],
             struct import_object *base_imports, uint32_t *wasi_exit_code_p);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ set(lib_core_sources
 	"leb128.c"
 	"list.c"
 	"load_context.c"
+	"mem.c"
 	"module.c"
 	"name.c"
 	"nbio.c"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -76,6 +76,7 @@ set(lib_core_headers
 	"list.h"
 	"load_context.h"
 	"lock.h"
+	"mem.h"
 	"module.h"
 	"module_writer.h"
 	"name.h"

--- a/lib/bitmap.c
+++ b/lib/bitmap.c
@@ -2,14 +2,15 @@
 #include <stdlib.h>
 
 #include "bitmap.h"
+#include "mem.h"
 #include "util.h"
 
 int
-bitmap_alloc(struct bitmap *b, uint32_t n)
+bitmap_alloc(struct mem_context *mctx, struct bitmap *b, uint32_t n)
 {
         void *p = NULL;
         if (n > 0) {
-                p = calloc(HOWMANY(n, 32), sizeof(uint32_t));
+                p = mem_calloc(mctx, HOWMANY(n, 32), sizeof(uint32_t));
                 if (p == NULL) {
                         return ENOMEM;
                 }
@@ -19,9 +20,9 @@ bitmap_alloc(struct bitmap *b, uint32_t n)
 }
 
 void
-bitmap_free(struct bitmap *b)
+bitmap_free(struct mem_context *mctx, struct bitmap *b, uint32_t n)
 {
-        free(b->data);
+        mem_free(mctx, b->data, HOWMANY(n, 32) * sizeof(uint32_t));
 }
 
 void

--- a/lib/bitmap.h
+++ b/lib/bitmap.h
@@ -16,8 +16,9 @@ __BEGIN_EXTERN_C
  * Note: a bitmap initalized by bitmap_alloc has all bits cleared.
  */
 
-int bitmap_alloc(struct bitmap *b, uint32_t n);
-void bitmap_free(struct bitmap *b);
+struct mem_context;
+int bitmap_alloc(struct mem_context *mctx, struct bitmap *b, uint32_t n);
+void bitmap_free(struct mem_context *mctx, struct bitmap *b, uint32_t n);
 void bitmap_set(struct bitmap *b, uint32_t idx);
 bool bitmap_test(const struct bitmap *b, uint32_t idx);
 

--- a/lib/context.h
+++ b/lib/context.h
@@ -7,6 +7,7 @@
 #include "platform.h"
 
 struct localtype;
+struct mem_context;
 struct module;
 
 /*
@@ -63,8 +64,8 @@ __BEGIN_EXTERN_C
 uint32_t ptr2pc(const struct module *m, const uint8_t *p) __purefunc;
 const uint8_t *pc2ptr(const struct module *m, uint32_t pc) __purefunc;
 
-int resulttype_alloc(uint32_t ntypes, const enum valtype *types,
-                     struct resulttype **resultp);
-void resulttype_free(struct resulttype *p);
+int resulttype_alloc(struct mem_context *mctx, uint32_t ntypes,
+                     const enum valtype *types, struct resulttype **resultp);
+void resulttype_free(struct mem_context *mctx, struct resulttype *p);
 
 __END_EXTERN_C

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -74,10 +74,10 @@ fail:
 }
 
 int
-read_vec_u32(const uint8_t **pp, const uint8_t *ep, uint32_t *countp,
+read_vec_u32(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, uint32_t *countp,
              uint32_t **resultp)
 {
-        return read_vec(pp, ep, sizeof(uint32_t),
+        return read_vec(mctx, pp, ep, sizeof(uint32_t),
                         (read_elem_func_t)read_leb_u32, NULL, countp,
                         (void *)resultp);
 }
@@ -89,7 +89,7 @@ read_vec_u32(const uint8_t **pp, const uint8_t *ep, uint32_t *countp,
  * - the ctx pointer
  */
 int
-_read_vec_with_ctx_impl(const uint8_t **pp, const uint8_t *ep,
+_read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
                         size_t elem_size,
                         int (*read_elem)(const uint8_t **pp, const uint8_t *ep,
                                          uint32_t idx, void *elem, void *),
@@ -107,7 +107,7 @@ _read_vec_with_ctx_impl(const uint8_t **pp, const uint8_t *ep,
                 goto fail;
         }
         uint32_t total_count = orig_count + vec_count;
-        ret = resize_array(resultp, elem_size, total_count);
+        ret = resize_array(mctx, resultp, elem_size, orig_count, total_count);
         if (ret != 0) {
                 goto fail;
         }
@@ -154,13 +154,13 @@ read_elem_wrapper(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
 }
 
 int
-read_vec(const uint8_t **pp, const uint8_t *ep, size_t elem_size,
+read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, size_t elem_size,
          int (*read_elem)(const uint8_t **pp, const uint8_t *ep, void *elem),
          void (*clear_elem)(void *elem), uint32_t *countp, void **resultp)
 {
         struct read_vec_ctx ctx = {
                 .read_elem = read_elem,
         };
-        return _read_vec_with_ctx_impl(pp, ep, elem_size, read_elem_wrapper,
+        return _read_vec_with_ctx_impl(mctx, pp, ep, elem_size, read_elem_wrapper,
                                        clear_elem, &ctx, countp, resultp);
 }

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -123,7 +123,10 @@ _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
                                         clear_elem(mctx, a + j * elem_size);
                                 }
                         }
-                        /* is it worth shrinking the array? */
+                        /* revert the array size */
+                        int ret1 = resize_array(mctx, resultp, elem_size,
+                                                total_count, orig_count);
+                        assert(ret1 == 0);
                         goto fail;
                 }
         }
@@ -133,10 +136,6 @@ _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
         *countp = total_count;
         return 0;
 fail:
-        if (orig_count == 0) {
-                free(*resultp);
-                *resultp = NULL;
-        }
         return ret;
 }
 

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -74,8 +74,8 @@ fail:
 }
 
 int
-read_vec_u32(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, uint32_t *countp,
-             uint32_t **resultp)
+read_vec_u32(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
+             uint32_t *countp, uint32_t **resultp)
 {
         return read_vec(mctx, pp, ep, sizeof(uint32_t),
                         (read_elem_func_t)read_leb_u32, NULL, countp,
@@ -89,8 +89,8 @@ read_vec_u32(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, ui
  * - the ctx pointer
  */
 int
-_read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
-                        size_t elem_size,
+_read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
+                        const uint8_t *ep, size_t elem_size,
                         int (*read_elem)(const uint8_t **pp, const uint8_t *ep,
                                          uint32_t idx, void *elem, void *),
                         void (*clear_elem)(void *elem), void *ctx,
@@ -154,13 +154,15 @@ read_elem_wrapper(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
 }
 
 int
-read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, size_t elem_size,
+read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
+         size_t elem_size,
          int (*read_elem)(const uint8_t **pp, const uint8_t *ep, void *elem),
          void (*clear_elem)(void *elem), uint32_t *countp, void **resultp)
 {
         struct read_vec_ctx ctx = {
                 .read_elem = read_elem,
         };
-        return _read_vec_with_ctx_impl(mctx, pp, ep, elem_size, read_elem_wrapper,
-                                       clear_elem, &ctx, countp, resultp);
+        return _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,
+                                       read_elem_wrapper, clear_elem, &ctx,
+                                       countp, resultp);
 }

--- a/lib/decode.h
+++ b/lib/decode.h
@@ -18,16 +18,17 @@ typedef int (*read_elem_func_t)(const uint8_t **pp, const uint8_t *ep,
                                 void *elem);
 typedef int (*read_elem_with_ctx_func_t)(const uint8_t **pp, const uint8_t *ep,
                                          uint32_t idx, void *elem, void *ctx);
-typedef void (*clear_elem_func_t)(void *elem);
+typedef void (*clear_elem_with_ctx_func_t)(struct mem_context *mctx,
+                                           void *elem);
 
 int read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
-             size_t elem_size, read_elem_func_t read_elem,
-             clear_elem_func_t clear_elem, uint32_t *countp, void **resultp);
+             size_t elem_size, read_elem_func_t read_elem, uint32_t *countp,
+             void **resultp);
 
 int _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
                             const uint8_t *ep, size_t elem_size,
                             read_elem_with_ctx_func_t read_elem,
-                            clear_elem_func_t clear_elem, void *ctx,
+                            clear_elem_with_ctx_func_t clear_elem, void *ctx,
                             uint32_t *countp, void **resultp);
 
 /*
@@ -49,20 +50,21 @@ int _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
         ({                                                                    \
                 int (*_r)(const uint8_t **, const uint8_t *, uint32_t,        \
                           toywasm_typeof(*resultp), void *) = read_elem;      \
-                void (*_c)(toywasm_typeof(*resultp)) = clear_elem;            \
+                void (*_c)(struct mem_context *, toywasm_typeof(*resultp)) =  \
+                        clear_elem;                                           \
                 assert(sizeof(**resultp) == elem_size);                       \
                 _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,              \
                                         (read_elem_with_ctx_func_t)_r,        \
-                                        (clear_elem_func_t)_c, ctx, countp,   \
-                                        (void **)resultp);                    \
+                                        (clear_elem_with_ctx_func_t)_c, ctx,  \
+                                        countp, (void **)resultp);            \
         })
 #else
 #define read_vec_with_ctx(mctx, pp, ep, elem_size, read_elem, clear_elem,     \
                           ctx, countp, resultp)                               \
         _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,                      \
                                 (read_elem_with_ctx_func_t)read_elem,         \
-                                (clear_elem_func_t)clear_elem, ctx, countp,   \
-                                (void **)resultp)
+                                (clear_elem_with_ctx_func_t)clear_elem, ctx,  \
+                                countp, (void **)resultp)
 #endif
 
 struct name;

--- a/lib/decode.h
+++ b/lib/decode.h
@@ -11,8 +11,8 @@ int read_u32(const uint8_t **pp, const uint8_t *ep, uint32_t *resultp);
 int read_u64(const uint8_t **pp, const uint8_t *ep, uint64_t *resultp);
 
 int read_vec_count(const uint8_t **pp, const uint8_t *ep, uint32_t *resultp);
-int read_vec_u32(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, uint32_t *countp,
-                 uint32_t **resultp);
+int read_vec_u32(struct mem_context *mctx, const uint8_t **pp,
+                 const uint8_t *ep, uint32_t *countp, uint32_t **resultp);
 
 typedef int (*read_elem_func_t)(const uint8_t **pp, const uint8_t *ep,
                                 void *elem);
@@ -20,12 +20,12 @@ typedef int (*read_elem_with_ctx_func_t)(const uint8_t **pp, const uint8_t *ep,
                                          uint32_t idx, void *elem, void *ctx);
 typedef void (*clear_elem_func_t)(void *elem);
 
-int read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep, size_t elem_size,
-             read_elem_func_t read_elem, clear_elem_func_t clear_elem,
-             uint32_t *countp, void **resultp);
+int read_vec(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
+             size_t elem_size, read_elem_func_t read_elem,
+             clear_elem_func_t clear_elem, uint32_t *countp, void **resultp);
 
-int _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp, const uint8_t *ep,
-                            size_t elem_size,
+int _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
+                            const uint8_t *ep, size_t elem_size,
                             read_elem_with_ctx_func_t read_elem,
                             clear_elem_func_t clear_elem, void *ctx,
                             uint32_t *countp, void **resultp);
@@ -44,24 +44,25 @@ int _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp, const 
 
 #if defined(toywasm_typeof)
 /* a version with non-standard checks */
-#define read_vec_with_ctx(mctx, pp, ep, elem_size, read_elem, clear_elem, ctx,      \
-                          countp, resultp)                                    \
+#define read_vec_with_ctx(mctx, pp, ep, elem_size, read_elem, clear_elem,     \
+                          ctx, countp, resultp)                               \
         ({                                                                    \
                 int (*_r)(const uint8_t **, const uint8_t *, uint32_t,        \
                           toywasm_typeof(*resultp), void *) = read_elem;      \
                 void (*_c)(toywasm_typeof(*resultp)) = clear_elem;            \
                 assert(sizeof(**resultp) == elem_size);                       \
-                _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,                    \
+                _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,              \
                                         (read_elem_with_ctx_func_t)_r,        \
                                         (clear_elem_func_t)_c, ctx, countp,   \
                                         (void **)resultp);                    \
         })
 #else
-#define read_vec_with_ctx(mctx, pp, ep, elem_size, read_elem, clear_elem, ctx,      \
-                          countp, resultp)                                    \
-        _read_vec_with_ctx_impl(mctx,                                              \
-                pp, ep, elem_size, (read_elem_with_ctx_func_t)read_elem,      \
-                (clear_elem_func_t)clear_elem, ctx, countp, (void **)resultp)
+#define read_vec_with_ctx(mctx, pp, ep, elem_size, read_elem, clear_elem,     \
+                          ctx, countp, resultp)                               \
+        _read_vec_with_ctx_impl(mctx, pp, ep, elem_size,                      \
+                                (read_elem_with_ctx_func_t)read_elem,         \
+                                (clear_elem_func_t)clear_elem, ctx, countp,   \
+                                (void **)resultp)
 #endif
 
 struct name;

--- a/lib/exec.c
+++ b/lib/exec.c
@@ -198,7 +198,8 @@ frame_enter(struct exec_context *ctx, struct instance *inst, uint32_t funcidx,
 #endif
         if (ei->maxlabels > 1) {
                 frame->labelidx = ctx->labels.lsize;
-                ret = VEC_PREALLOC(exec_mctx(ctx), ctx->labels, ei->maxlabels - 1);
+                ret = VEC_PREALLOC(exec_mctx(ctx), ctx->labels,
+                                   ei->maxlabels - 1);
                 if (ret != 0) {
                         return ret;
                 }

--- a/lib/exec.c
+++ b/lib/exec.c
@@ -1495,10 +1495,12 @@ exec_const_expr(const struct expr *expr, enum valtype type, struct val *result,
 }
 
 void
-exec_context_init(struct exec_context *ctx, struct instance *inst)
+exec_context_init(struct exec_context *ctx, struct instance *inst,
+                  struct mem_context *mctx)
 {
         memset(ctx, 0, sizeof(*ctx));
         ctx->instance = inst;
+        ctx->mctx = mctx;
         report_init(&ctx->report0);
         ctx->report = &ctx->report0;
         ctx->check_interval = CHECK_INTERVAL_DEFAULT;
@@ -1508,17 +1510,18 @@ exec_context_init(struct exec_context *ctx, struct instance *inst)
 void
 exec_context_clear(struct exec_context *ctx)
 {
+        struct mem_context *mctx = exec_mctx(ctx);
         struct funcframe *frame;
         VEC_FOREACH(frame, ctx->frames) {
                 frame_clear(frame);
         }
-        VEC_FREE(exec_mctx(ctx), ctx->frames);
-        VEC_FREE(exec_mctx(ctx), ctx->stack);
-        VEC_FREE(exec_mctx(ctx), ctx->labels);
+        VEC_FREE(mctx, ctx->frames);
+        VEC_FREE(mctx, ctx->stack);
+        VEC_FREE(mctx, ctx->labels);
 #if defined(TOYWASM_USE_SEPARATE_LOCALS)
-        VEC_FREE(exec_mctx(ctx), ctx->locals);
+        VEC_FREE(mctx, ctx->locals);
 #endif
-        VEC_FREE(exec_mctx(ctx), ctx->restarts);
+        VEC_FREE(mctx, ctx->restarts);
         report_clear(&ctx->report0);
         ctx->report = NULL;
 }

--- a/lib/exec.c
+++ b/lib/exec.c
@@ -67,7 +67,7 @@ stack_prealloc(struct exec_context *ctx, uint32_t count)
                 return trap_with_id(ctx, TRAP_TOO_MANY_STACKCELLS,
                                     "too many values on the operand stack");
         }
-        return VEC_PREALLOC(ctx->stack, count);
+        return VEC_PREALLOC(exec_mctx(ctx), ctx->stack, count);
 }
 
 static void
@@ -177,7 +177,7 @@ frame_enter(struct exec_context *ctx, struct instance *inst, uint32_t funcidx,
                 return trap_with_id(ctx, TRAP_TOO_MANY_FRAMES,
                                     "too many frames");
         }
-        ret = VEC_PREALLOC(ctx->frames, 1);
+        ret = VEC_PREALLOC(exec_mctx(ctx), ctx->frames, 1);
         if (ret != 0) {
                 return ret;
         }
@@ -191,14 +191,14 @@ frame_enter(struct exec_context *ctx, struct instance *inst, uint32_t funcidx,
         frame->labelidx = ctx->labels.lsize;
 #if defined(TOYWASM_USE_SEPARATE_LOCALS)
         frame->localidx = ctx->locals.lsize;
-        ret = VEC_PREALLOC(ctx->locals, nlocals);
+        ret = VEC_PREALLOC(exec_mctx(ctx), ctx->locals, nlocals);
         if (ret != 0) {
                 return ret;
         }
 #endif
         if (ei->maxlabels > 1) {
                 frame->labelidx = ctx->labels.lsize;
-                ret = VEC_PREALLOC(ctx->labels, ei->maxlabels - 1);
+                ret = VEC_PREALLOC(exec_mctx(ctx), ctx->labels, ei->maxlabels - 1);
                 if (ret != 0) {
                         return ret;
                 }
@@ -1511,13 +1511,13 @@ exec_context_clear(struct exec_context *ctx)
         VEC_FOREACH(frame, ctx->frames) {
                 frame_clear(frame);
         }
-        VEC_FREE(ctx->frames);
-        VEC_FREE(ctx->stack);
-        VEC_FREE(ctx->labels);
+        VEC_FREE(exec_mctx(ctx), ctx->frames);
+        VEC_FREE(exec_mctx(ctx), ctx->stack);
+        VEC_FREE(exec_mctx(ctx), ctx->labels);
 #if defined(TOYWASM_USE_SEPARATE_LOCALS)
-        VEC_FREE(ctx->locals);
+        VEC_FREE(exec_mctx(ctx), ctx->locals);
 #endif
-        VEC_FREE(ctx->restarts);
+        VEC_FREE(exec_mctx(ctx), ctx->restarts);
         report_clear(&ctx->report0);
         ctx->report = NULL;
 }

--- a/lib/exec_context.h
+++ b/lib/exec_context.h
@@ -314,12 +314,16 @@ struct exec_context {
         void *exec_done_arg;
 #endif
 
+		struct mem_context *mctx;
+
         /* Options */
         struct exec_options options;
 
         /* Statistics */
         struct exec_stat stats;
 };
+
+#define exec_mctx(ectx) (ectx)->mctx
 
 /* For funcframe.funcidx */
 #define FUNCIDX_INVALID UINT32_MAX

--- a/lib/exec_context.h
+++ b/lib/exec_context.h
@@ -314,7 +314,7 @@ struct exec_context {
         void *exec_done_arg;
 #endif
 
-		struct mem_context *mctx;
+        struct mem_context *mctx;
 
         /* Options */
         struct exec_options options;

--- a/lib/exec_context.h
+++ b/lib/exec_context.h
@@ -12,6 +12,7 @@
 #include "vec.h"
 
 struct val;
+struct mem_context;
 
 struct label {
         uint32_t pc;
@@ -333,7 +334,8 @@ struct exec_context {
 
 __BEGIN_EXTERN_C
 
-void exec_context_init(struct exec_context *ctx, struct instance *inst);
+void exec_context_init(struct exec_context *ctx, struct instance *inst,
+                       struct mem_context *mctx);
 void exec_context_clear(struct exec_context *ctx);
 void exec_context_print_stats(struct exec_context *ctx);
 

--- a/lib/exec_insn_subr.c
+++ b/lib/exec_insn_subr.c
@@ -402,7 +402,6 @@ memory_grow_impl(struct exec_context *ctx, struct meminst *mi, uint32_t sz)
         const struct memtype *mt = mi->type;
         const struct limits *lim = &mt->lim;
         const uint32_t page_shift = memtype_page_shift(mt);
-        const uint32_t page_size = 1 << page_shift;
         /*
          * In case of non-shared memory, no serialization is necessary.
          * in that case, memory_lock is no-op.
@@ -469,7 +468,7 @@ retry:
                         if (mi->size_in_pages != orig_size) {
                                 goto retry;
                         }
-                        assert((mi->allocated % page_size) == 0);
+                        assert((mi->allocated % (1 << page_shift)) == 0);
                 }
 #endif /* defined(TOYWASM_ENABLE_WASM_THREADS) */
                 assert(new_size > mi->allocated >> page_shift);

--- a/lib/exec_insn_subr.c
+++ b/lib/exec_insn_subr.c
@@ -104,7 +104,8 @@ do_trap:
 #endif
                 size_t need = (size_t)last_byte + 1;
                 assert(need > meminst->allocated);
-                void *np = mem_resize(meminst->mctx, meminst->data, meminst->allocated, need);
+                void *np = mem_resize(meminst->mctx, meminst->data,
+                                      meminst->allocated, need);
                 if (np == NULL) {
                         return ENOMEM;
                 }
@@ -477,16 +478,18 @@ retry:
                 if (new_size_in_bytes >> page_shift != new_size) {
                         ret = EOVERFLOW;
                 } else {
-                        void *np = mem_resize(mi->mctx, mi->data, mi->allocated, new_size_in_bytes);
+                        void *np =
+                                mem_resize(mi->mctx, mi->data, mi->allocated,
+                                           new_size_in_bytes);
                         if (np == NULL) {
-                            ret = ENOMEM;
+                                ret = ENOMEM;
                         } else {
-                        ret = 0;
-                            mi->data = np;
-                        assert(new_size_in_bytes > mi->allocated);
-                        memset(mi->data + mi->allocated, 0,
-                               new_size_in_bytes - mi->allocated);
-                        mi->allocated = new_size_in_bytes;
+                                ret = 0;
+                                mi->data = np;
+                                assert(new_size_in_bytes > mi->allocated);
+                                memset(mi->data + mi->allocated, 0,
+                                       new_size_in_bytes - mi->allocated);
+                                mi->allocated = new_size_in_bytes;
                         }
                 }
 #if defined(TOYWASM_ENABLE_WASM_THREADS)

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -242,8 +242,6 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
         return 0;
 fail:
         validation_context_reuse(vctx);
-        free(ei->jumps);
-        ei->jumps = NULL;
         return ret;
 }
 

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -263,7 +263,12 @@ read_const_expr(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                 enum valtype type, struct load_context *lctx)
 {
         DEFINE_RESULTTYPE(, resulttype, &type, 1);
-
-        return read_expr_common(pp, ep, expr, 0, NULL, empty_rt, &resulttype,
-                                true, lctx);
+        int ret = read_expr_common(pp, ep, expr, 0, NULL, empty_rt,
+                                   &resulttype, true, lctx);
+        /* a const expr does never require these annotations */
+        assert(expr->ei.jumps == NULL);
+#if defined(TOYWASM_USE_SMALL_CELLS)
+        assert(expr->ei.type_annotations.types == NULL);
+#endif
+        return ret;
 }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -167,10 +167,11 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
         vctx->options = &lctx->options;
         struct expr_exec_info *ei;
         vctx->ei = ei = &expr->ei;
+        vctx->mctx = lctx->mctx;
         memset(ei, 0, sizeof(*ei));
 
         uint32_t lsize = parameter_types->ntypes + nlocals;
-        ret = VEC_PREALLOC(vctx->locals, lsize);
+        ret = VEC_PREALLOC(vctx->mctx, vctx->locals, lsize);
         if (ret != 0) {
                 goto fail;
         }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -163,17 +163,16 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
                 vctx->module = lctx->module;
                 vctx->report = &lctx->report;
                 vctx->refs = &lctx->refs;
-                vctx->has_datacount = lctx->has_datacount;
-                vctx->ndatas_in_datacount = lctx->ndatas_in_datacount;
                 vctx->options = &lctx->options;
         } else {
                 assert(vctx->module == lctx->module);
                 assert(vctx->report == &lctx->report);
                 assert(vctx->refs == &lctx->refs);
-                assert(vctx->has_datacount == lctx->has_datacount);
-                assert(vctx->ndatas_in_datacount == lctx->ndatas_in_datacount);
                 assert(vctx->options == &lctx->options);
         }
+        /* note: const exprs can come before the datacount section */
+        vctx->has_datacount = lctx->has_datacount;
+        vctx->ndatas_in_datacount = lctx->ndatas_in_datacount;
         vctx->const_expr = const_expr;
         struct expr_exec_info *ei;
         vctx->ei = ei = &expr->ei;

--- a/lib/expr.h
+++ b/lib/expr.h
@@ -6,9 +6,11 @@ struct expr;
 struct resulttype;
 struct localchunk;
 struct load_context;
+struct mem_context;
 struct module;
 
-int get_functype_for_blocktype(struct module *m, int64_t blocktype,
+int get_functype_for_blocktype(struct mem_context *mctx, struct module *m,
+                               int64_t blocktype,
                                struct resulttype **parameter,
                                struct resulttype **result);
 

--- a/lib/host_instance.c
+++ b/lib/host_instance.c
@@ -34,7 +34,7 @@ import_object_create_for_host_funcs(struct mem_context *mctx,
                                     size_t n, struct host_instance *hi,
                                     struct import_object **impp)
 {
-        struct import_object *im;
+        struct import_object *im = NULL;
         struct funcinst *fis = NULL;
         size_t nfuncs;
         size_t i;
@@ -89,7 +89,9 @@ import_object_create_for_host_funcs(struct mem_context *mctx,
         *impp = im;
         return 0;
 fail:
-        import_object_destroy(mctx, im);
+        if (im != NULL) {
+                import_object_destroy(mctx, im);
+        }
         return ret;
 }
 

--- a/lib/host_instance.c
+++ b/lib/host_instance.c
@@ -49,7 +49,7 @@ import_object_create_for_host_funcs(const struct host_module *modules,
         if (ret != 0) {
                 goto fail;
         }
-        fis = zalloc(nfuncs * sizeof(*fis));
+        fis = xzalloc(nfuncs * sizeof(*fis));
         if (fis == NULL) {
                 ret = ENOMEM;
                 goto fail;

--- a/lib/host_instance.c
+++ b/lib/host_instance.c
@@ -67,8 +67,9 @@ import_object_create_for_host_funcs(struct mem_context *mctx,
                         struct functype *ft;
                         ret = functype_from_string(mctx, func->type, &ft);
                         if (ret != 0) {
-                                xlog_error("failed to parse functype: %s",
-                                           func->type);
+                                xlog_error("failed to parse functype %s with "
+                                           "error %d",
+                                           func->type, ret);
                                 goto fail;
                         }
                         struct funcinst *fi = &fis[idx];

--- a/lib/host_instance.h
+++ b/lib/host_instance.h
@@ -63,7 +63,7 @@ struct host_func {
 #endif
 
 struct host_instance {
-        int dummy;
+        struct mem_context *mctx;
 };
 
 struct host_module {
@@ -75,7 +75,9 @@ struct host_module {
 __BEGIN_EXTERN_C
 
 struct import_object;
-int import_object_create_for_host_funcs(const struct host_module *modules,
+struct mem_context;
+int import_object_create_for_host_funcs(struct mem_context *mctx,
+                                        const struct host_module *modules,
                                         size_t n, struct host_instance *hi,
                                         struct import_object **impp);
 

--- a/lib/idalloc.c
+++ b/lib/idalloc.c
@@ -25,13 +25,13 @@ idalloc_init(struct idalloc *ida, uint32_t minid, uint32_t maxid)
 }
 
 void
-idalloc_destroy(struct idalloc *ida)
+idalloc_destroy(struct idalloc *ida, struct mem_context *mctx)
 {
-        VEC_FREE(ida->mctx, ida->vec);
+        VEC_FREE(mctx, ida->vec);
 }
 
 int
-idalloc_alloc(struct idalloc *ida, uint32_t *idp)
+idalloc_alloc(struct idalloc *ida, uint32_t *idp, struct mem_context *mctx)
 {
         void **it;
         uint32_t id;
@@ -47,7 +47,7 @@ idalloc_alloc(struct idalloc *ida, uint32_t *idp)
         if (ida->maxid < id) {
                 return ERANGE;
         }
-        ret = VEC_RESIZE(ida->mctx, ida->vec, id + 1);
+        ret = VEC_RESIZE(mctx, ida->vec, id + 1);
         if (ret != 0) {
                 return ret;
         }
@@ -57,7 +57,7 @@ idalloc_alloc(struct idalloc *ida, uint32_t *idp)
 }
 
 void
-idalloc_free(struct idalloc *ida, uint32_t id)
+idalloc_free(struct idalloc *ida, uint32_t id, struct mem_context *mctx)
 {
         assert(idalloc_test(ida, id));
         *idalloc_getptr(ida, id) = FREE_SLOT;

--- a/lib/idalloc.c
+++ b/lib/idalloc.c
@@ -27,7 +27,7 @@ idalloc_init(struct idalloc *ida, uint32_t minid, uint32_t maxid)
 void
 idalloc_destroy(struct idalloc *ida)
 {
-        VEC_FREE(ida->vec);
+        VEC_FREE(ida->mctx, ida->vec);
 }
 
 int
@@ -47,7 +47,7 @@ idalloc_alloc(struct idalloc *ida, uint32_t *idp)
         if (ida->maxid < id) {
                 return ERANGE;
         }
-        ret = VEC_RESIZE(ida->vec, id + 1);
+        ret = VEC_RESIZE(ida->mctx, ida->vec, id + 1);
         if (ret != 0) {
                 return ret;
         }

--- a/lib/idalloc.h
+++ b/lib/idalloc.h
@@ -9,6 +9,7 @@ struct idalloc {
         VEC(, void *) vec;
         uint32_t base;
         uint32_t maxid;
+        struct mem_context *mctx;
 };
 
 __BEGIN_EXTERN_C

--- a/lib/idalloc.h
+++ b/lib/idalloc.h
@@ -5,20 +5,22 @@
 #include "platform.h"
 #include "vec.h"
 
+struct mem_context;
+
 struct idalloc {
         VEC(, void *) vec;
         uint32_t base;
         uint32_t maxid;
-        struct mem_context *mctx;
 };
 
 __BEGIN_EXTERN_C
 
 void idalloc_init(struct idalloc *ida, uint32_t minid, uint32_t maxid);
-void idalloc_destroy(struct idalloc *ida);
+void idalloc_destroy(struct idalloc *ida, struct mem_context *mctx);
 
-int idalloc_alloc(struct idalloc *ida, uint32_t *idp);
-void idalloc_free(struct idalloc *ida, uint32_t id);
+int idalloc_alloc(struct idalloc *ida, uint32_t *idp,
+                  struct mem_context *mctx);
+void idalloc_free(struct idalloc *ida, uint32_t id, struct mem_context *mctx);
 bool idalloc_test(struct idalloc *ida, uint32_t id);
 
 void idalloc_set_user(struct idalloc *ida, uint32_t id, void *user_data);

--- a/lib/import_object.c
+++ b/lib/import_object.c
@@ -12,13 +12,13 @@ import_object_alloc(uint32_t nentries, struct import_object **resultp)
 {
         struct import_object *im;
 
-        im = zalloc(sizeof(*im));
+        im = xzalloc(sizeof(*im));
         if (im == NULL) {
                 return ENOMEM;
         }
         im->nentries = nentries;
         if (nentries > 0) {
-                im->entries = zalloc(nentries * sizeof(*im->entries));
+                im->entries = xzalloc(nentries * sizeof(*im->entries));
                 if (im->entries == NULL) {
                         free(im);
                         return ENOMEM;

--- a/lib/insn.c
+++ b/lib/insn.c
@@ -300,8 +300,8 @@ get_functype(struct module *m, uint32_t typeidx, struct functype **ftp)
 #define BYTE_AS_S33(b) ((int)(signed char)((b) + 0x80))
 
 int
-get_functype_for_blocktype(struct module *m, int64_t blocktype,
-                           struct resulttype **parameter,
+get_functype_for_blocktype(struct mem_context *mctx, struct module *m,
+                           int64_t blocktype, struct resulttype **parameter,
                            struct resulttype **result)
 {
         int ret;
@@ -321,7 +321,7 @@ get_functype_for_blocktype(struct module *m, int64_t blocktype,
                         struct resulttype *rt;
                         enum valtype t = u8;
 
-                        ret = resulttype_alloc(1, &t, &rt);
+                        ret = resulttype_alloc(mctx, 1, &t, &rt);
                         if (ret != 0) {
                                 return ret;
                         }

--- a/lib/insn.c
+++ b/lib/insn.c
@@ -19,6 +19,7 @@
 #include "insn_op.h"
 #include "insn_op_helpers.h"
 #include "leb128.h"
+#include "mem.h"
 #include "platform.h"
 #include "type.h"
 #include "util.h"

--- a/lib/insn_impl_control.h
+++ b/lib/insn_impl_control.h
@@ -362,10 +362,10 @@ INSN_IMPL(br_table)
         struct mem_context *mctx;
         struct mem_context mctx0;
         if (VALIDATING) {
-            mctx = VCTX->mctx;
-		} else {
-            mctx = &mctx0;
-            mem_context_init(mctx);
+                mctx = VCTX->mctx;
+        } else {
+                mctx = &mctx0;
+                mem_context_init(mctx);
         }
         ret = read_vec_u32(mctx, &p, ep, &vec_count, &table);
         CHECK_RET(ret);
@@ -404,8 +404,8 @@ INSN_IMPL(br_table)
         }
         mem_free(mctx, table, vec_count * sizeof(uint32_t));
         if (!VALIDATING) {
-            mem_context_clear(mctx);
-		}
+                mem_context_clear(mctx);
+        }
         SAVE_PC;
         INSN_SUCCESS;
 fail:

--- a/lib/insn_impl_control.h
+++ b/lib/insn_impl_control.h
@@ -409,7 +409,9 @@ INSN_IMPL(br_table)
         SAVE_PC;
         INSN_SUCCESS;
 fail:
-        mem_free(mctx, table, vec_count * sizeof(uint32_t));
+        if (table != NULL) {
+                mem_free(mctx, table, vec_count * sizeof(uint32_t));
+        }
         INSN_FAIL;
 }
 

--- a/lib/insn_impl_control.h
+++ b/lib/insn_impl_control.h
@@ -409,7 +409,7 @@ INSN_IMPL(br_table)
         SAVE_PC;
         INSN_SUCCESS;
 fail:
-        free(table);
+        mem_free(mctx, table, vec_count * sizeof(uint32_t));
         INSN_FAIL;
 }
 

--- a/lib/insn_impl_eh.h
+++ b/lib/insn_impl_eh.h
@@ -23,6 +23,7 @@
 INSN_IMPL(try_table)
 {
         int ret;
+        struct mem_context *mctx = NULL;
         struct resulttype *rt_parameter = NULL;
         struct resulttype *rt_result = NULL;
 #if defined(__GNUC__) && !defined(__clang__)
@@ -35,8 +36,9 @@ INSN_IMPL(try_table)
         if (VALIDATING) {
                 struct validation_context *vctx = VCTX;
                 struct module *m = vctx->module;
-                ret = get_functype_for_blocktype(m, blocktype, &rt_parameter,
-                                                 &rt_result);
+                mctx = validation_mctx(vctx);
+                ret = get_functype_for_blocktype(mctx, m, blocktype,
+                                                 &rt_parameter, &rt_result);
                 if (ret != 0) {
                         goto fail;
                 }
@@ -151,8 +153,10 @@ INSN_IMPL(try_table)
         SAVE_PC;
         INSN_SUCCESS;
 fail:
-        resulttype_free(rt_parameter);
-        resulttype_free(rt_result);
+        if (mctx != NULL) {
+                resulttype_free(mctx, rt_parameter);
+                resulttype_free(mctx, rt_result);
+        }
         INSN_FAIL;
 }
 

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -7,8 +7,8 @@
 #include "bitmap.h"
 #include "exec.h"
 #include "instance.h"
-#include "module.h"
 #include "mem.h"
+#include "module.h"
 #include "nbio.h"
 #include "shared_memory_impl.h"
 #include "suspend.h"
@@ -185,7 +185,8 @@ memory_instance_create(struct mem_context *mctx, struct meminst **mip,
                 if (need_in_bytes > 0) {
                         mp->data = mem_zalloc(mctx->need_in_bytes);
                         if (mp->data == NULL) {
-                                mem_free(mctx, mp->shared, sizeof(*mp->shared));
+                                mem_free(mctx, mp->shared,
+                                         sizeof(*mp->shared));
                                 mem_free(mctx, mp, sizeof(*mp));
                                 ret = ENOMEM;
                                 goto fail;
@@ -224,7 +225,8 @@ memory_instance_destroy(struct mem_context *mctx, struct meminst *mi)
 }
 
 int
-global_instance_create(struct mem_context *mctx, struct globalinst **gip, const struct globaltype *gt)
+global_instance_create(struct mem_context *mctx, struct globalinst **gip,
+                       const struct globaltype *gt)
 {
         struct globalinst *ginst;
         int ret;
@@ -249,7 +251,8 @@ global_instance_destroy(struct mem_context *mctx, struct globalinst *gi)
 
 #if defined(TOYWASM_ENABLE_WASM_EXCEPTION_HANDLING)
 int
-tag_instance_create(struct mem_context *mctx, struct taginst **tip, const struct functype *ft)
+tag_instance_create(struct mem_context *mctx, struct taginst **tip,
+                    const struct functype *ft)
 {
         struct taginst *ti;
         int ret;
@@ -273,7 +276,8 @@ tag_instance_destroy(struct mem_context *mctx, struct taginst *ti)
 #endif
 
 int
-table_instance_create(struct mem_context *mctx, struct tableinst **tip, const struct tabletype *tt)
+table_instance_create(struct mem_context *mctx, struct tableinst **tip,
+                      const struct tabletype *tt)
 {
         struct tableinst *tinst;
         int ret;
@@ -309,9 +313,9 @@ fail:
 }
 
 void
-table_instance_destroy(struct mem_context *mctx ,struct tableinst *ti)
+table_instance_destroy(struct mem_context *mctx, struct tableinst *ti)
 {
-		assert(mctx == ti->mctx);
+        assert(mctx == ti->mctx);
         if (ti != NULL) {
                 uint32_t csz = valtype_cellsize(ti->type->et);
                 size_t ncells = (size_t)ti->size * csz;
@@ -324,8 +328,9 @@ table_instance_destroy(struct mem_context *mctx ,struct tableinst *ti)
  */
 
 int
-instance_create(struct mem_context *mctx, const struct module *m, struct instance **instp,
-                const struct import_object *imports, struct report *report)
+instance_create(struct mem_context *mctx, const struct module *m,
+                struct instance **instp, const struct import_object *imports,
+                struct report *report)
 {
         struct instance *inst;
         int ret;
@@ -448,7 +453,8 @@ fail:
 }
 
 int
-instance_create_no_init(struct mem_context *mctx, const struct module *m, struct instance **instp,
+instance_create_no_init(struct mem_context *mctx, const struct module *m,
+                        struct instance **instp,
                         const struct import_object *imports,
                         struct report *report)
 {

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -558,11 +558,11 @@ instance_create_no_init(struct mem_context *mctx, const struct module *m,
                 VEC_ELEM(inst->tags, i) = tinst;
         }
 #endif /* defined(TOYWASM_ENABLE_WASM_EXCEPTION_HANDLING) */
-        ret = bitmap_alloc(&inst->data_dropped, m->ndatas);
+        ret = bitmap_alloc(mctx, &inst->data_dropped, m->ndatas);
         if (ret != 0) {
                 goto fail;
         }
-        ret = bitmap_alloc(&inst->elem_dropped, m->nelems);
+        ret = bitmap_alloc(mctx, &inst->elem_dropped, m->nelems);
         if (ret != 0) {
                 goto fail;
         }
@@ -689,8 +689,8 @@ instance_destroy(struct instance *inst)
         }
         VEC_FREE(mctx, inst->tags);
 #endif
-        bitmap_free(&inst->data_dropped);
-        bitmap_free(&inst->elem_dropped);
+        bitmap_free(mctx, &inst->data_dropped, m->ndatas);
+        bitmap_free(mctx, &inst->elem_dropped, m->nelems);
         mem_free(mctx, inst, sizeof(*inst));
 }
 

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -146,7 +146,7 @@ void table_instance_destroy(struct mem_context *mctx, struct tableinst *ti);
  * mainly for wasi-threads, where it's host's responsibility to
  * provide the linear memory.
  */
-int create_satisfying_shared_memories(const struct module *module,
+int create_satisfying_shared_memories(struct mem_context *mctx, const struct module *module,
                                       struct import_object **imop);
 
 void instance_print_stats(const struct instance *inst);

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -9,6 +9,7 @@ struct resulttype;
 struct import;
 struct import_object;
 struct import_object_entry;
+struct mem_context;
 struct report;
 struct name;
 
@@ -18,7 +19,7 @@ __BEGIN_EXTERN_C
  * This API is inspired from js-api.
  * https://webassembly.github.io/spec/js-api/index.html#instances
  */
-int instance_create(const struct module *m, struct instance **instp,
+int instance_create(struct mem_context *mctx, const struct module *m, struct instance **instp,
                     const struct import_object *imports,
                     struct report *report);
 
@@ -32,7 +33,7 @@ int instance_create(const struct module *m, struct instance **instp,
  * note than instance_execute_init can return a restartable error.
  * see also: instance_execute_continue.
  */
-int instance_create_no_init(const struct module *m, struct instance **instp,
+int instance_create_no_init(struct mem_context *mctx, const struct module *m, struct instance **instp,
                             const struct import_object *imports,
                             struct report *report);
 int instance_execute_init(struct exec_context *ctx);
@@ -122,19 +123,19 @@ int import_object_find_entry(
 
 struct meminst;
 struct memtype;
-int memory_instance_create(struct meminst **mip, const struct memtype *mt);
-void memory_instance_destroy(struct meminst *mi);
+int memory_instance_create(struct mem_context *mctx, struct meminst **mip, const struct memtype *mt);
+void memory_instance_destroy(struct mem_context *mctx, struct meminst *mi);
 
 struct globalinst;
 struct globaltype;
-int global_instance_create(struct globalinst **gip,
+int global_instance_create(struct mem_context *mctx, struct globalinst **gip,
                            const struct globaltype *gt);
-void global_instance_destroy(struct globalinst *gi);
+void global_instance_destroy(struct mem_context *mctx, struct globalinst *gi);
 
 struct tableinst;
 struct tabletype;
-int table_instance_create(struct tableinst **tip, const struct tabletype *tt);
-void table_instance_destroy(struct tableinst *ti);
+int table_instance_create(struct mem_context *mctx, struct tableinst **tip, const struct tabletype *tt);
+void table_instance_destroy(struct mem_context *mctx, struct tableinst *ti);
 
 /*
  * create_satisfying_shared_memories:

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -19,7 +19,8 @@ __BEGIN_EXTERN_C
  * This API is inspired from js-api.
  * https://webassembly.github.io/spec/js-api/index.html#instances
  */
-int instance_create(struct mem_context *mctx, const struct module *m, struct instance **instp,
+int instance_create(struct mem_context *mctx, const struct module *m,
+                    struct instance **instp,
                     const struct import_object *imports,
                     struct report *report);
 
@@ -33,7 +34,8 @@ int instance_create(struct mem_context *mctx, const struct module *m, struct ins
  * note than instance_execute_init can return a restartable error.
  * see also: instance_execute_continue.
  */
-int instance_create_no_init(struct mem_context *mctx, const struct module *m, struct instance **instp,
+int instance_create_no_init(struct mem_context *mctx, const struct module *m,
+                            struct instance **instp,
                             const struct import_object *imports,
                             struct report *report);
 int instance_execute_init(struct exec_context *ctx);
@@ -123,7 +125,8 @@ int import_object_find_entry(
 
 struct meminst;
 struct memtype;
-int memory_instance_create(struct mem_context *mctx, struct meminst **mip, const struct memtype *mt);
+int memory_instance_create(struct mem_context *mctx, struct meminst **mip,
+                           const struct memtype *mt);
 void memory_instance_destroy(struct mem_context *mctx, struct meminst *mi);
 
 struct globalinst;
@@ -134,7 +137,8 @@ void global_instance_destroy(struct mem_context *mctx, struct globalinst *gi);
 
 struct tableinst;
 struct tabletype;
-int table_instance_create(struct mem_context *mctx, struct tableinst **tip, const struct tabletype *tt);
+int table_instance_create(struct mem_context *mctx, struct tableinst **tip,
+                          const struct tabletype *tt);
 void table_instance_destroy(struct mem_context *mctx, struct tableinst *ti);
 
 /*
@@ -146,7 +150,8 @@ void table_instance_destroy(struct mem_context *mctx, struct tableinst *ti);
  * mainly for wasi-threads, where it's host's responsibility to
  * provide the linear memory.
  */
-int create_satisfying_shared_memories(struct mem_context *mctx, const struct module *module,
+int create_satisfying_shared_memories(struct mem_context *mctx,
+                                      const struct module *module,
                                       struct import_object **imop);
 
 void instance_print_stats(const struct instance *inst);

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -112,11 +112,13 @@ int instance_execute_handle_restart_once(struct exec_context *ctx,
 /*
  * see the comment in type.h about the concept of import_object.
  */
-int import_object_create_for_exports(struct instance *inst,
+int import_object_create_for_exports(struct mem_context *mctx,
+                                     struct instance *inst,
                                      const struct name *module_name,
                                      struct import_object **resultp);
-void import_object_destroy(struct import_object *im);
-int import_object_alloc(uint32_t nentries, struct import_object **resultp);
+void import_object_destroy(struct mem_context *mctx, struct import_object *im);
+int import_object_alloc(struct mem_context *mctx, uint32_t nentries,
+                        struct import_object **resultp);
 int import_object_find_entry(
         const struct import_object *impobj, const struct import *im,
         int (*check)(const struct import_object_entry *e, const void *arg),

--- a/lib/load_context.c
+++ b/lib/load_context.c
@@ -1,9 +1,9 @@
 #include <errno.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "context.h"
 #include "load_context.h"
+#include "mem.h"
 #include "validation.h"
 
 void
@@ -23,6 +23,6 @@ load_context_clear(struct load_context *ctx)
         bitmap_free(mctx, &ctx->refs, ctx->refs_size);
         if (ctx->vctx != NULL) {
                 validation_context_clear(ctx->vctx);
-                free(ctx->vctx);
+                mem_free(mctx, ctx->vctx, sizeof(*ctx->vctx));
         }
 }

--- a/lib/load_context.c
+++ b/lib/load_context.c
@@ -7,9 +7,10 @@
 #include "validation.h"
 
 void
-load_context_init(struct load_context *ctx)
+load_context_init(struct load_context *ctx, struct mem_context *mctx)
 {
         memset(ctx, 0, sizeof(*ctx));
+        ctx->mctx = mctx;
         report_init(&ctx->report);
         load_options_set_defaults(&ctx->options);
 }

--- a/lib/load_context.c
+++ b/lib/load_context.c
@@ -18,8 +18,9 @@ load_context_init(struct load_context *ctx, struct mem_context *mctx)
 void
 load_context_clear(struct load_context *ctx)
 {
+        struct mem_context *mctx = load_mctx(ctx);
         report_clear(&ctx->report);
-        bitmap_free(&ctx->refs);
+        bitmap_free(mctx, &ctx->refs, ctx->refs_size);
         if (ctx->vctx != NULL) {
                 validation_context_clear(ctx->vctx);
                 free(ctx->vctx);

--- a/lib/load_context.h
+++ b/lib/load_context.h
@@ -21,7 +21,7 @@ struct load_context {
 
 __BEGIN_EXTERN_C
 
-void load_context_init(struct load_context *ctx);
+void load_context_init(struct load_context *ctx, struct mem_context *mctx);
 void load_context_clear(struct load_context *ctx);
 
 __END_EXTERN_C

--- a/lib/load_context.h
+++ b/lib/load_context.h
@@ -10,6 +10,7 @@ struct load_context {
         struct module *module;
         struct report report;
         struct bitmap refs; /* C.refs */
+        uint32_t refs_size;
         bool has_datacount;
         uint32_t ndatas_in_datacount;
         struct load_options options;

--- a/lib/load_context.h
+++ b/lib/load_context.h
@@ -13,8 +13,11 @@ struct load_context {
         bool has_datacount;
         uint32_t ndatas_in_datacount;
         struct load_options options;
+        struct mem_context *mctx;
         struct validation_context *vctx;
 };
+
+#define load_mctx(l) (l)->mctx
 
 __BEGIN_EXTERN_C
 

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdatomic.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -32,23 +32,22 @@ mem_alloc(struct mem_context *ctx, size_t sz)
 void *
 mem_zalloc(struct mem_context *ctx, size_t sz)
 {
-	void *p = mem_alloc(ctx, sz);
-    if (p != NULL) {
-        memset(p, 0, sz);
-    }
-    return p;
+        void *p = mem_alloc(ctx, sz);
+        if (p != NULL) {
+                memset(p, 0, sz);
+        }
+        return p;
 }
 
 void *
 mem_calloc(struct mem_context *ctx, size_t a, size_t b)
 {
-	size_t sz = a * b;
-    if (sz / a != b) {
-        return NULL;
-    }
-    return mem_zalloc(ctx, sz);
+        size_t sz = a * b;
+        if (sz / a != b) {
+                return NULL;
+        }
+        return mem_zalloc(ctx, sz);
 }
-
 
 static int
 mem_reserve(struct mem_context *ctx, size_t diff)

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mem.h"
+
+void
+mem_context_init(struct mem_context *ctx)
+{
+        ctx->allocated = 0;
+        ctx->limit = SIZE_MAX;
+}
+
+void
+mem_context_clear(struct mem_context *ctx)
+{
+        assert(ctx->allocated == 0);
+}
+
+void *
+mem_alloc(struct mem_context *ctx, size_t sz)
+{
+        void *p = malloc(sz);
+        if (p == NULL) {
+                return NULL;
+        }
+        return p;
+}
+
+void *
+mem_zalloc(struct mem_context *ctx, size_t sz)
+{
+	void *p = mem_alloc(ctx, sz);
+    if (p != NULL) {
+        memset(p, 0, sz);
+    }
+    return p;
+}
+
+void *
+mem_calloc(struct mem_context *ctx, size_t a, size_t b)
+{
+	size_t sz = a * b;
+    if (sz / a != b) {
+        return NULL;
+    }
+    return mem_zalloc(ctx, sz);
+}
+
+
+static int
+mem_reserve(struct mem_context *ctx, size_t diff)
+{
+        size_t ov;
+        size_t nv;
+        do {
+                ov = ctx->allocated;
+                assert(ov <= ctx->limit);
+                if (ctx->limit - ov < diff) {
+                        return ENOMEM;
+                }
+                nv = ov + diff;
+        } while (!atomic_compare_exchange_weak(&ctx->allocated, &ov, nv));
+        return 0;
+}
+
+static void
+mem_unreserve(struct mem_context *ctx, size_t diff)
+{
+        assert(ctx->allocated <= ctx->limit);
+        assert(ctx->allocated >= diff);
+        size_t ov = atomic_fetch_sub(&ctx->allocated, diff);
+        assert(ctx->allocated >= ov);
+}
+
+void
+mem_free(struct mem_context *ctx, void *p, size_t sz)
+{
+        free(p);
+        mem_unreserve(ctx, sz);
+}
+
+void *
+mem_resize(struct mem_context *ctx, void *p, size_t oldsz, size_t newsz)
+{
+        if (oldsz < newsz) {
+                size_t diff = newsz - oldsz;
+                if (mem_reserve(ctx, diff)) {
+                        return NULL;
+                }
+        } else {
+                size_t diff = oldsz - newsz;
+                mem_unreserve(ctx, diff);
+        }
+        void *np = realloc(p, newsz);
+        if (np == NULL) {
+                return NULL;
+        }
+        return np;
+}

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -86,6 +86,16 @@ mem_context_clear(struct mem_context *ctx)
         assert(ctx->allocated == 0);
 }
 
+int
+mem_context_setlimit(struct mem_context *ctx, size_t limit)
+{
+        if (limit < ctx->allocated) {
+                return ENOMEM;
+        }
+        ctx->limit = limit;
+        return 0;
+}
+
 void *
 mem_alloc(struct mem_context *ctx, size_t sz)
 {

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(NDEBUG) && defined(__APPLE__)
+#include <malloc/malloc.h>
+#endif
+
 #include "mem.h"
 
 static void
@@ -82,6 +86,8 @@ mem_zalloc(struct mem_context *ctx, size_t sz)
 void *
 mem_calloc(struct mem_context *ctx, size_t a, size_t b)
 {
+        assert(a > 0);
+        assert(b > 0);
         size_t sz = a * b;
         if (sz / a != b) {
                 return NULL;
@@ -96,6 +102,10 @@ mem_free(struct mem_context *ctx, void *p, size_t sz)
                 return;
         }
         assert(sz > 0);
+#if !defined(NDEBUG) && defined(__APPLE__)
+        size_t msz = malloc_size(p);
+        assert(msz == sz);
+#endif
         free(p);
         mem_unreserve(ctx, sz);
 }

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -1,0 +1,16 @@
+#include <stddef.h>
+
+#include "platform.h"
+
+struct mem_context {
+        _Atomic size_t allocated;
+        size_t limit;
+};
+
+void mem_context_init(struct mem_context *ctx);
+void mem_context_clear(struct mem_context *ctx);
+void *__must_check mem_alloc(struct mem_context *ctx, size_t sz) __malloc_like __alloc_size(2);
+void *__must_check mem_zalloc(struct mem_context *ctx, size_t sz) __malloc_like __alloc_size(2);
+void *__must_check mem_calloc(struct mem_context *ctx, size_t a, size_t b);
+void mem_free(struct mem_context *ctx, void *p, size_t sz);
+void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz, size_t newsz) __malloc_like __alloc_size(4);

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -1,3 +1,6 @@
+#if !defined(_TOYWASM_MEM_H)
+#define _TOYWASM_MEM_H
+
 #include <stddef.h>
 
 #include "platform.h"
@@ -22,3 +25,5 @@ void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz,
                               size_t newsz) __malloc_like __alloc_size(4);
 
 __END_EXTERN_C
+
+#endif /* !defined(_TOYWASM_MEM_H) */

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -5,6 +5,7 @@
 struct mem_context {
         _Atomic size_t allocated;
         size_t limit;
+        struct mem_context *parent;
 };
 
 void mem_context_init(struct mem_context *ctx);

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -15,6 +15,7 @@ __BEGIN_EXTERN_C
 
 void mem_context_init(struct mem_context *ctx);
 void mem_context_clear(struct mem_context *ctx);
+int __must_check mem_context_setlimit(struct mem_context *ctx, size_t limit);
 void *__must_check mem_alloc(struct mem_context *ctx, size_t sz) __malloc_like
         __alloc_size(2);
 void *__must_check mem_zalloc(struct mem_context *ctx, size_t sz) __malloc_like

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -8,6 +8,8 @@ struct mem_context {
         struct mem_context *parent;
 };
 
+__BEGIN_EXTERN_C
+
 void mem_context_init(struct mem_context *ctx);
 void mem_context_clear(struct mem_context *ctx);
 void *__must_check mem_alloc(struct mem_context *ctx, size_t sz) __malloc_like
@@ -18,3 +20,5 @@ void *__must_check mem_calloc(struct mem_context *ctx, size_t a, size_t b);
 void mem_free(struct mem_context *ctx, void *p, size_t sz);
 void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz,
                               size_t newsz) __malloc_like __alloc_size(4);
+
+__END_EXTERN_C

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -9,8 +9,11 @@ struct mem_context {
 
 void mem_context_init(struct mem_context *ctx);
 void mem_context_clear(struct mem_context *ctx);
-void *__must_check mem_alloc(struct mem_context *ctx, size_t sz) __malloc_like __alloc_size(2);
-void *__must_check mem_zalloc(struct mem_context *ctx, size_t sz) __malloc_like __alloc_size(2);
+void *__must_check mem_alloc(struct mem_context *ctx, size_t sz) __malloc_like
+        __alloc_size(2);
+void *__must_check mem_zalloc(struct mem_context *ctx, size_t sz) __malloc_like
+        __alloc_size(2);
 void *__must_check mem_calloc(struct mem_context *ctx, size_t a, size_t b);
 void mem_free(struct mem_context *ctx, void *p, size_t sz);
-void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz, size_t newsz) __malloc_like __alloc_size(4);
+void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz,
+                              size_t newsz) __malloc_like __alloc_size(4);

--- a/lib/module.c
+++ b/lib/module.c
@@ -1904,7 +1904,8 @@ static void
 clear_dylink(struct mem_context *mctx, struct dylink *dy)
 {
         clear_dylink_needs(mctx, &dy->needs);
-        mem_free(mctx, dy->import_info, sizeof(*dy->import_info));
+        mem_free(mctx, dy->import_info,
+                 dy->nimport_info * sizeof(*dy->import_info));
 }
 
 /* https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md

--- a/lib/module.c
+++ b/lib/module.c
@@ -1915,7 +1915,7 @@ read_dylink_0_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         struct module *m = ctx->module;
         int ret;
-        m->dylink = mem_zalloc(loader_mctx(ctx), sizeof(*m->dylink));
+        m->dylink = mem_zalloc(load_mctx(ctx), sizeof(*m->dylink));
         if (m->dylink == NULL) {
                 ret = ENOMEM;
                 goto fail;

--- a/lib/module.c
+++ b/lib/module.c
@@ -1004,6 +1004,9 @@ read_locals(const uint8_t **pp, const uint8_t *ep, struct func *func,
         if (vec_count > 0) {
                 chunks =
                         mem_calloc(load_mctx(ctx), vec_count, sizeof(*chunks));
+                if (chunks == NULL) {
+                        return ENOMEM;
+                }
         }
 
         uint32_t i;

--- a/lib/module.c
+++ b/lib/module.c
@@ -1531,10 +1531,10 @@ fail:
 static void
 module_funcs_clear(struct mem_context *mctx, struct module *m, uint32_t nfuncs)
 {
-        assert((m->funcs == NULL) == (nfuncs == 0));
         if (m->funcs == NULL) {
                 return;
         }
+        assert(nfuncs > 0);
         uint32_t i;
         for (i = 0; i < nfuncs; i++) {
                 clear_func(mctx, &m->funcs[i]);

--- a/lib/module.c
+++ b/lib/module.c
@@ -19,8 +19,8 @@
 #include "expr.h"
 #include "leb128.h"
 #include "load_context.h"
-#include "module.h"
 #include "mem.h"
+#include "module.h"
 #include "nbio.h"
 #include "report.h"
 #include "type.h"
@@ -820,8 +820,9 @@ read_type_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx),&p, ep, sizeof(*m->types), read_functype,
-                                clear_functype, ctx, &m->ntypes, &m->types);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->types),
+                                read_functype, clear_functype, ctx, &m->ntypes,
+                                &m->types);
         if (ret != 0) {
                 goto fail;
         }
@@ -845,8 +846,9 @@ read_import_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(struct import), read_import,
-                                clear_import, ctx, &m->nimports, &m->imports);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(struct import),
+                                read_import, clear_import, ctx, &m->nimports,
+                                &m->imports);
         if (ret != 0) {
                 goto fail;
         }
@@ -1080,7 +1082,8 @@ read_function_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_u32(load_mctx(ctx), &p, ep, &m->nfuncs, &m->functypeidxes);
+        ret = read_vec_u32(load_mctx(ctx), &p, ep, &m->nfuncs,
+                           &m->functypeidxes);
         if (ret != 0) {
                 goto fail;
         }
@@ -1150,8 +1153,8 @@ read_memory_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->mems), read_memtype, NULL,
-                                ctx, &m->nmems, &m->mems);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->mems),
+                                read_memtype, NULL, ctx, &m->nmems, &m->mems);
         if (ret != 0) {
                 xlog_trace("failed to load mems with %d", ret);
                 goto fail;
@@ -1206,8 +1209,9 @@ read_global_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->globals), read_global,
-                                clear_global, ctx, &m->nglobals, &m->globals);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->globals),
+                                read_global, clear_global, ctx, &m->nglobals,
+                                &m->globals);
         if (ret != 0) {
                 goto fail;
         }
@@ -1233,9 +1237,9 @@ read_export_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(struct wasm_export),
-                                read_export, clear_export, ctx, &m->nexports,
-                                &m->exports);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep,
+                                sizeof(struct wasm_export), read_export,
+                                clear_export, ctx, &m->nexports, &m->exports);
         if (ret != 0) {
                 goto fail;
         }
@@ -1432,7 +1436,8 @@ read_element(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
                  * vec(funcidx)
                  */
                 assert(elem->type == TYPE_FUNCREF);
-                ret = read_vec_u32(load_mctx(ctx), &p, ep, &elem->init_size, &elem->funcs);
+                ret = read_vec_u32(load_mctx(ctx), &p, ep, &elem->init_size,
+                                   &elem->funcs);
                 if (ret != 0) {
                         goto fail;
                 }
@@ -1452,10 +1457,10 @@ read_element(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
                 /*
                  * vec(expr)
                  */
-                ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*elem->init_exprs),
-                                        read_element_init_expr, clear_expr,
-                                        &init_expr_ctx, &elem->init_size,
-                                        &elem->init_exprs);
+                ret = read_vec_with_ctx(
+                        load_mctx(ctx), &p, ep, sizeof(*elem->init_exprs),
+                        read_element_init_expr, clear_expr, &init_expr_ctx,
+                        &elem->init_size, &elem->init_exprs);
                 if (ret != 0) {
                         goto fail;
                 }
@@ -1499,8 +1504,9 @@ read_element_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->elems), read_element,
-                                clear_element, ctx, &m->nelems, &m->elems);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->elems),
+                                read_element, clear_element, ctx, &m->nelems,
+                                &m->elems);
         if (ret != 0) {
                 goto fail;
         }
@@ -1526,8 +1532,9 @@ read_code_section(const uint8_t **pp, const uint8_t *ep,
 
         assert(m->funcs == NULL);
         uint32_t nfuncs_in_code = 0;
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->funcs), read_func,
-                                clear_func, ctx, &nfuncs_in_code, &m->funcs);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->funcs),
+                                read_func, clear_func, ctx, &nfuncs_in_code,
+                                &m->funcs);
         if (ret != 0) {
                 assert(nfuncs_in_code == 0);
                 goto fail;
@@ -1638,8 +1645,9 @@ read_data_section(const uint8_t **pp, const uint8_t *ep,
         const uint8_t *p = *pp;
         int ret;
 
-        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->datas), read_data,
-                                clear_data, ctx, &m->ndatas, &m->datas);
+        ret = read_vec_with_ctx(load_mctx(ctx), &p, ep, sizeof(*m->datas),
+                                read_data, clear_data, ctx, &m->ndatas,
+                                &m->datas);
         if (ret != 0) {
                 goto fail;
         }
@@ -2227,8 +2235,8 @@ module_create0(struct mem_context *mctx, struct module **mp)
 }
 
 int
-module_create(struct mem_context *mctx, struct module **mp, const uint8_t *p, const uint8_t *ep,
-              struct load_context *ctx)
+module_create(struct mem_context *mctx, struct module **mp, const uint8_t *p,
+              const uint8_t *ep, struct load_context *ctx)
 {
         struct module *m;
         int ret = module_create0(mctx, &m);
@@ -2260,7 +2268,8 @@ module_unload(struct mem_context *mctx, struct module *m)
                 }
                 mem_free(mctx, m->funcs, m->nfuncs * sizeof(*m->funcs));
         }
-        mem_free(mctx, m->functypeidxes, m->nfuncs * sizeof(*m->functypeidxes));
+        mem_free(mctx, m->functypeidxes,
+                 m->nfuncs * sizeof(*m->functypeidxes));
 
         mem_free(mctx, m->tables, m->ntables * sizeof(*m->tables));
         mem_free(mctx, m->mems, m->nmems * sizeof(*m->mems));

--- a/lib/module.h
+++ b/lib/module.h
@@ -9,7 +9,8 @@ struct mem_context;
 
 __BEGIN_EXTERN_C
 
-int module_create(struct mem_context *mctx, struct module **mp, const uint8_t *p, const uint8_t *ep,
+int module_create(struct mem_context *mctx, struct module **mp,
+                  const uint8_t *p, const uint8_t *ep,
                   struct load_context *ctx);
 void module_destroy(struct mem_context *mctx, struct module *m);
 int module_find_export(const struct module *m, const struct name *name,

--- a/lib/module.h
+++ b/lib/module.h
@@ -9,8 +9,7 @@ struct mem_context;
 
 __BEGIN_EXTERN_C
 
-int module_create(struct mem_context *mctx, struct module **mp,
-                  const uint8_t *p, const uint8_t *ep,
+int module_create(struct module **mp, const uint8_t *p, const uint8_t *ep,
                   struct load_context *ctx);
 void module_destroy(struct mem_context *mctx, struct module *m);
 int module_find_export(const struct module *m, const struct name *name,

--- a/lib/module.h
+++ b/lib/module.h
@@ -5,12 +5,13 @@
 struct load_context;
 struct module;
 struct name;
+struct mem_context;
 
 __BEGIN_EXTERN_C
 
-int module_create(struct module **mp, const uint8_t *p, const uint8_t *ep,
+int module_create(struct mem_context *mctx, struct module **mp, const uint8_t *p, const uint8_t *ep,
                   struct load_context *ctx);
-void module_destroy(struct module *m);
+void module_destroy(struct mem_context *mctx, struct module *m);
 int module_find_export(const struct module *m, const struct name *name,
                        uint32_t type, uint32_t *idxp);
 int module_find_export_func(const struct module *m, const struct name *name,

--- a/lib/name.c
+++ b/lib/name.c
@@ -85,11 +85,6 @@ read_naming(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
         return 0;
 }
 
-void
-clear_naming(struct naming *ft)
-{
-}
-
 /* https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md#name-map
  */
 static int
@@ -102,8 +97,8 @@ parse_namemap(struct nametable *table, struct namemap *map,
         ctx.module = m;
         map->entries = NULL;
         ret = read_vec_with_ctx(&table->mctx, &p, ep, sizeof(struct naming),
-                                read_naming, clear_naming, &ctx,
-                                &map->nentries, &map->entries);
+                                read_naming, NULL, &ctx, &map->nentries,
+                                &map->entries);
         if (ret != 0) {
                 goto fail;
         }

--- a/lib/name.c
+++ b/lib/name.c
@@ -239,6 +239,7 @@ void
 nametable_init(struct nametable *table)
 {
 #if defined(TOYWASM_ENABLE_WASM_NAME_SECTION)
+        mem_context_init(&table->mctx);
         namemap_init(&table->funcs);
         table->module_name.data = NULL;
         table->module = NULL;

--- a/lib/name.c
+++ b/lib/name.c
@@ -93,17 +93,17 @@ clear_naming(struct naming *ft)
 /* https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md#name-map
  */
 static int
-parse_namemap(struct nametable *table, struct namemap *map, const struct module *m, const uint8_t *p,
-              const uint8_t *ep)
+parse_namemap(struct nametable *table, struct namemap *map,
+              const struct module *m, const uint8_t *p, const uint8_t *ep)
 {
         struct read_naming_context ctx;
         int ret;
 
         ctx.module = m;
         map->entries = NULL;
-        ret = read_vec_with_ctx(&table->mctx, &p, ep, sizeof(struct naming), read_naming,
-                                clear_naming, &ctx, &map->nentries,
-                                &map->entries);
+        ret = read_vec_with_ctx(&table->mctx, &p, ep, sizeof(struct naming),
+                                read_naming, clear_naming, &ctx,
+                                &map->nentries, &map->entries);
         if (ret != 0) {
                 goto fail;
         }
@@ -203,7 +203,8 @@ namemap_init(struct namemap *map)
 static void
 namemap_clear(struct nametable *table, struct namemap *map)
 {
-        mem_free(&table->mctx, map->entries, map->nentries * sizeof(*map->entries));
+        mem_free(&table->mctx, map->entries,
+                 map->nentries * sizeof(*map->entries));
         map->nentries = 0;
         map->entries = NULL;
 }

--- a/lib/name.h
+++ b/lib/name.h
@@ -1,3 +1,4 @@
+#include "mem.h"
 #include "type.h"
 
 __BEGIN_EXTERN_C
@@ -13,6 +14,7 @@ struct nametable {
         const struct module *module;
         struct name module_name;
         struct namemap funcs;
+        struct mem_context mctx;
 };
 
 void nametable_init(struct nametable *table);

--- a/lib/restart.c
+++ b/lib/restart.c
@@ -36,7 +36,7 @@ restart_info_prealloc(struct exec_context *ctx)
         if (ctx->restarts.lsize < ctx->restarts.psize) {
                 return 0;
         }
-        int ret = VEC_PREALLOC(ctx->restarts, 1);
+        int ret = VEC_PREALLOC(exec_mctx(ctx), ctx->restarts, 1);
         if (ret != 0) {
                 return ret;
         }

--- a/lib/shared_memory.c
+++ b/lib/shared_memory.c
@@ -11,13 +11,13 @@ _dtor(struct import_object *imo)
                 struct import_object_entry *e = &imo->entries[i];
                 struct meminst *mi = e->u.mem;
                 if (mi != NULL) {
-                        memory_instance_destroy(mi);
+                        memory_instance_destroy(mi->mctx, mi);
                 }
         }
 }
 
 int
-create_satisfying_shared_memories(const struct module *m,
+create_satisfying_shared_memories(struct mem_context *mctx, const struct module *m,
                                   struct import_object **imop)
 {
         struct import_object *imo = NULL;
@@ -55,7 +55,7 @@ create_satisfying_shared_memories(const struct module *m,
                 if ((mt->flags & MEMTYPE_FLAG_SHARED) == 0) {
                         continue;
                 }
-                ret = memory_instance_create(&mi, mt);
+                ret = memory_instance_create(mctx, &mi, mt);
                 if (ret != 0) {
                         goto fail;
                 }
@@ -74,7 +74,7 @@ fail:
                 import_object_destroy(imo);
         }
         if (mi != NULL) {
-                memory_instance_destroy(mi);
+                memory_instance_destroy(mctx, mi);
         }
         return ret;
 }

--- a/lib/shared_memory.c
+++ b/lib/shared_memory.c
@@ -17,7 +17,8 @@ _dtor(struct import_object *imo)
 }
 
 int
-create_satisfying_shared_memories(struct mem_context *mctx, const struct module *m,
+create_satisfying_shared_memories(struct mem_context *mctx,
+                                  const struct module *m,
                                   struct import_object **imop)
 {
         struct import_object *imo = NULL;

--- a/lib/shared_memory.c
+++ b/lib/shared_memory.c
@@ -4,14 +4,14 @@
 #include "type.h"
 
 static void
-_dtor(struct import_object *imo)
+_dtor(struct mem_context *mctx, struct import_object *imo)
 {
         uint32_t i;
         for (i = 0; i < imo->nentries; i++) {
                 struct import_object_entry *e = &imo->entries[i];
                 struct meminst *mi = e->u.mem;
                 if (mi != NULL) {
-                        memory_instance_destroy(mi->mctx, mi);
+                        memory_instance_destroy(mctx, mi);
                 }
         }
 }
@@ -40,7 +40,7 @@ create_satisfying_shared_memories(struct mem_context *mctx,
                 nsharedimports++;
         }
 
-        ret = import_object_alloc(nsharedimports, &imo);
+        ret = import_object_alloc(mctx, nsharedimports, &imo);
         if (ret != 0) {
                 goto fail;
         }
@@ -72,7 +72,7 @@ create_satisfying_shared_memories(struct mem_context *mctx,
         return 0;
 fail:
         if (imo != NULL) {
-                import_object_destroy(imo);
+                import_object_destroy(mctx, imo);
         }
         if (mi != NULL) {
                 memory_instance_destroy(mctx, mi);

--- a/lib/type.h
+++ b/lib/type.h
@@ -578,6 +578,7 @@ struct meminst {
          */
         struct shared_meminst *shared;
 #endif
+		struct mem_context *mctx;
 };
 
 struct globalinst {
@@ -598,6 +599,7 @@ struct tableinst {
         struct cell *cells;
         uint32_t size; /* overrides type->min */
         const struct tabletype *type;
+        struct mem_context *mctx;
 };
 
 #if defined(TOYWASM_ENABLE_WASM_EXCEPTION_HANDLING)
@@ -635,6 +637,8 @@ struct instance {
          */
         struct bitmap data_dropped;
         struct bitmap elem_dropped;
+
+        struct mem_context *mctx;
 };
 
 /*

--- a/lib/type.h
+++ b/lib/type.h
@@ -677,7 +677,7 @@ struct import_object {
 #endif
         size_t nentries;
         struct import_object_entry *entries;
-        void (*dtor)(struct import_object *im);
+        void (*dtor)(struct mem_context *mctx, struct import_object *im);
         void *dtor_arg;
         struct import_object *next; /* NULL for the last import_object */
 };
@@ -717,15 +717,16 @@ const struct functype *funcinst_functype(const struct funcinst *fi);
 const struct functype *taginst_functype(const struct taginst *ti);
 const struct func *funcinst_func(const struct funcinst *fi);
 
-int functype_from_string(const char *p, struct functype **resultp);
-void functype_free(struct functype *ft);
+int functype_from_string(struct mem_context *mctx, const char *p,
+                         struct functype **resultp);
+void functype_free(struct mem_context *mctx, struct functype *ft);
 int check_functype_with_string(const struct module *m, uint32_t funcidx,
                                const char *sig);
 int functype_to_string(char **p, const struct functype *ft);
 void functype_string_free(char *p);
 
-void clear_functype(struct functype *ft);
-void clear_resulttype(struct resulttype *rt);
+void clear_functype(struct mem_context *mctx, struct functype *ft);
+void clear_resulttype(struct mem_context *mctx, struct resulttype *rt);
 
 void set_name_cstr(struct name *name, const char *cstr);
 void clear_name(struct name *name);

--- a/lib/type.h
+++ b/lib/type.h
@@ -578,7 +578,7 @@ struct meminst {
          */
         struct shared_meminst *shared;
 #endif
-		struct mem_context *mctx;
+        struct mem_context *mctx;
 };
 
 struct globalinst {

--- a/lib/util.c
+++ b/lib/util.c
@@ -7,24 +7,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "mem.h"
 #include "util.h"
 
 int
-resize_array(void **p, size_t elem_size, uint32_t new_elem_count)
+resize_array(struct mem_context *mctx, void **p, size_t elem_size,
+             uint32_t old_elem_count, uint32_t new_elem_count)
 {
+        const size_t old_bytesize = elem_size * old_elem_count;
+        const size_t bytesize = elem_size * new_elem_count;
         void *np;
-        size_t bytesize;
 
         assert(elem_size > 0);
-        bytesize = elem_size * new_elem_count;
         if (bytesize / elem_size != new_elem_count) {
                 return EOVERFLOW;
         }
         if (bytesize == 0) {
-                free(*p);
+                mem_free(mctx, *p, old_bytesize);
                 np = NULL;
         } else {
-                np = realloc(*p, bytesize);
+                np = mem_resize(mctx, *p, old_bytesize, bytesize);
                 if (np == NULL) {
                         return ENOMEM;
                 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -33,9 +33,8 @@ resize_array(void **p, size_t elem_size, uint32_t new_elem_count)
         return 0;
 }
 
-#if !defined(__NuttX__) /* Avoid conflicting with libc zalloc */
 void *
-zalloc(size_t sz)
+xzalloc(size_t sz)
 {
         assert(sz > 0);
         void *p = malloc(sz);
@@ -44,7 +43,6 @@ zalloc(size_t sz)
         }
         return p;
 }
-#endif
 
 char *
 xstrnstr(const char *haystack, const char *needle, size_t len)

--- a/lib/util.h
+++ b/lib/util.h
@@ -5,15 +5,13 @@
 
 #define ARRAYCOUNT(a) (sizeof(a) / sizeof(a[0]))
 
-int __must_check resize_array(void **p, size_t elem_size,
-                              uint32_t new_elem_count);
-#if defined(__NuttX__)
-#include <stdlib.h> /* NuttX has zalloc() in stdlib */
-#else
-void *__must_check zalloc(size_t sz) __malloc_like __alloc_size(1);
-#endif
+void *__must_check xzalloc(size_t sz) __malloc_like __alloc_size(1);
 
-#define ARRAY_RESIZE(a, sz) resize_array((void **)&(a), sizeof(*a), sz)
+struct mem_context;
+int __must_check resize_array(struct mem_context *ctx, void **p, size_t elem_size,
+                              uint32_t old_elem_count, uint32_t new_elem_count);
+
+#define ARRAY_RESIZE(ctx, a, osz, sz) resize_array((ctx), (void **)&(a), sizeof(*a), osz, sz)
 #define ARRAY_FOREACH(p, a, sz) for (p = a; p < a + sz; p++)
 
 #define ZERO(p) memset(p, 0, sizeof(*p))

--- a/lib/util.h
+++ b/lib/util.h
@@ -8,10 +8,12 @@
 void *__must_check xzalloc(size_t sz) __malloc_like __alloc_size(1);
 
 struct mem_context;
-int __must_check resize_array(struct mem_context *ctx, void **p, size_t elem_size,
-                              uint32_t old_elem_count, uint32_t new_elem_count);
+int __must_check resize_array(struct mem_context *ctx, void **p,
+                              size_t elem_size, uint32_t old_elem_count,
+                              uint32_t new_elem_count);
 
-#define ARRAY_RESIZE(ctx, a, osz, sz) resize_array((ctx), (void **)&(a), sizeof(*a), osz, sz)
+#define ARRAY_RESIZE(ctx, a, osz, sz)                                         \
+        resize_array((ctx), (void **)&(a), sizeof(*a), osz, sz)
 #define ARRAY_FOREACH(p, a, sz) for (p = a; p < a + sz; p++)
 
 #define ZERO(p) memset(p, 0, sizeof(*p))

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -334,9 +334,10 @@ validation_context_init(struct validation_context *ctx)
 void
 validation_context_reuse(struct validation_context *ctx)
 {
+        struct mem_context *mctx = validation_mctx(ctx);
         struct ctrlframe *cframe;
         VEC_FOREACH(cframe, ctx->cframes) {
-                ctrlframe_clear(cframe);
+                ctrlframe_clear(mctx, cframe);
         }
         ctx->cframes.lsize = 0;
         ctx->valtypes.lsize = 0;
@@ -357,10 +358,10 @@ validation_context_clear(struct validation_context *ctx)
 }
 
 void
-ctrlframe_clear(struct ctrlframe *cframe)
+ctrlframe_clear(struct mem_context *mctx, struct ctrlframe *cframe)
 {
-        resulttype_free(cframe->end_types);
-        resulttype_free(cframe->start_types);
+        resulttype_free(mctx, cframe->end_types);
+        resulttype_free(mctx, cframe->start_types);
 }
 
 int

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "context.h"
+#include "mem.h"
 #include "options.h"
 #include "report.h"
 #include "type.h"

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -93,7 +93,7 @@ struct resulttype *returntype(struct validation_context *ctx);
 void validation_context_init(struct validation_context *ctx);
 void validation_context_reuse(struct validation_context *ctx);
 void validation_context_clear(struct validation_context *ctx);
-void ctrlframe_clear(struct ctrlframe *cframe);
+void ctrlframe_clear(struct mem_context *mctx, struct ctrlframe *cframe);
 int target_label_types(struct validation_context *ctx, uint32_t labelidx,
                        const struct resulttype **rtp);
 

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -64,6 +64,8 @@ struct validation_context {
 #endif
 };
 
+#define validation_mctx(ctx) (ctx)->mctx
+
 /* validation */
 
 int push_valtype(enum valtype type, struct validation_context *ctx);

--- a/lib/validation.h
+++ b/lib/validation.h
@@ -57,6 +57,7 @@ struct validation_context {
         struct bitmap *refs;
 
         const struct load_options *options;
+        struct mem_context *mctx;
 
 #if defined(TOYWASM_USE_SEPARATE_VALIDATE)
         const uint8_t *p;

--- a/lib/vec.c
+++ b/lib/vec.c
@@ -8,14 +8,16 @@
 VEC(_vec, void);
 
 int
-_vec_resize(void *vec, size_t elem_size, uint32_t new_elem_count)
+_vec_resize(struct mem_context *mctx, void *vec, size_t elem_size,
+            uint32_t new_elem_count)
 {
         struct _vec *v = vec;
         int ret;
         assert(v->lsize <= v->psize);
         assert((v->psize == 0) == (v->p == NULL));
         if (new_elem_count > v->psize) {
-                ret = resize_array((void **)&v->p, elem_size, new_elem_count);
+                ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize,
+                                   new_elem_count);
                 if (ret != 0) {
                         return ret;
                 }
@@ -30,13 +32,15 @@ _vec_resize(void *vec, size_t elem_size, uint32_t new_elem_count)
 }
 
 int
-_vec_prealloc(void *vec, size_t elem_size, uint32_t count)
+_vec_prealloc(struct mem_context *mctx, void *vec, size_t elem_size,
+              uint32_t count)
 {
         struct _vec *v = vec;
         int ret;
         uint32_t need = v->lsize + count;
         if (need > v->psize) {
-                ret = resize_array((void **)&v->p, elem_size, need);
+                ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize,
+                                   need);
                 if (ret != 0) {
                         return ret;
                 }
@@ -46,10 +50,11 @@ _vec_prealloc(void *vec, size_t elem_size, uint32_t count)
 }
 
 void
-_vec_free(void *vec)
+_vec_free(struct mem_context *mctx, void *vec, size_t elem_size)
 {
         struct _vec *v = vec;
-        free(v->p);
+        int ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize, 0);
+        assert(ret == 0);
         v->p = NULL;
         v->lsize = 0;
         v->psize = 0;

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -17,9 +17,10 @@ struct mem_context;
 
 __BEGIN_EXTERN_C
 
-int __must_check _vec_resize(struct mem_context *ctx, void *vec, size_t elem_size,
-                             uint32_t new_elem_count);
-int __must_check _vec_prealloc(struct mem_context *ctx, void *vec, size_t elem_size, uint32_t count);
+int __must_check _vec_resize(struct mem_context *ctx, void *vec,
+                             size_t elem_size, uint32_t new_elem_count);
+int __must_check _vec_prealloc(struct mem_context *ctx, void *vec,
+                               size_t elem_size, uint32_t count);
 void _vec_free(struct mem_context *ctx, void *vec);
 
 __END_EXTERN_C
@@ -36,7 +37,8 @@ __END_EXTERN_C
  * given number of elements. that is, psize >= lsize + needed.
  * it doesn't initialize newly allocated elements.
  */
-#define VEC_PREALLOC(ctx, v, needed) _vec_prealloc(ctx, &v, sizeof(*v.p), needed);
+#define VEC_PREALLOC(ctx, v, needed)                                          \
+        _vec_prealloc(ctx, &v, sizeof(*v.p), needed);
 #define VEC_FREE(ctx, v) _vec_free(ctx, &v)
 #define VEC_FOREACH(it, v) ARRAY_FOREACH(it, v.p, v.lsize)
 #define VEC_FOREACH_IDX(i, it, v) for (i = 0, it = v.p; i < v.lsize; i++, it++)

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -6,6 +6,8 @@
 #include "platform.h"
 #include "util.h"
 
+struct mem_context;
+
 #define VEC(TAG, TYPE)                                                        \
         struct TAG {                                                          \
                 TYPE *p;                                                      \
@@ -15,10 +17,10 @@
 
 __BEGIN_EXTERN_C
 
-int __must_check _vec_resize(void *vec, size_t elem_size,
+int __must_check _vec_resize(struct mem_context *ctx, void *vec, size_t elem_size,
                              uint32_t new_elem_count);
-int __must_check _vec_prealloc(void *vec, size_t elem_size, uint32_t count);
-void _vec_free(void *vec);
+int __must_check _vec_prealloc(struct mem_context *ctx, void *vec, size_t elem_size, uint32_t count);
+void _vec_free(struct mem_context *ctx, void *vec);
 
 __END_EXTERN_C
 
@@ -28,14 +30,14 @@ __END_EXTERN_C
  * when extending the vector, it initializes newly allocated elements
  * with zeros.
  */
-#define VEC_RESIZE(v, sz) _vec_resize(&v, sizeof(*v.p), sz);
+#define VEC_RESIZE(ctx, v, sz) _vec_resize(ctx, &v, sizeof(*v.p), sz);
 /*
  * VEC_PREALLOC ensures the vector to have enough tail room to store the
  * given number of elements. that is, psize >= lsize + needed.
  * it doesn't initialize newly allocated elements.
  */
-#define VEC_PREALLOC(v, needed) _vec_prealloc(&v, sizeof(*v.p), needed);
-#define VEC_FREE(v) _vec_free(&v)
+#define VEC_PREALLOC(ctx, v, needed) _vec_prealloc(ctx, &v, sizeof(*v.p), needed);
+#define VEC_FREE(ctx, v) _vec_free(ctx, &v)
 #define VEC_FOREACH(it, v) ARRAY_FOREACH(it, v.p, v.lsize)
 #define VEC_FOREACH_IDX(i, it, v) for (i = 0, it = v.p; i < v.lsize; i++, it++)
 #define VEC_ELEM(v, idx) (v.p[idx])

--- a/lib/vec.h
+++ b/lib/vec.h
@@ -21,15 +21,17 @@ int __must_check _vec_resize(struct mem_context *ctx, void *vec,
                              size_t elem_size, uint32_t new_elem_count);
 int __must_check _vec_prealloc(struct mem_context *ctx, void *vec,
                                size_t elem_size, uint32_t count);
-void _vec_free(struct mem_context *ctx, void *vec);
+void _vec_free(struct mem_context *ctx, void *vec, size_t elem_size);
 
 __END_EXTERN_C
 
 #define VEC_INIT(v) memset(&v, 0, sizeof(v))
 /*
- * VEC_RESIZE resizes the size of vector. that is, psize == lsize == sz.
+ * VEC_RESIZE resizes the size of vector. that is, psize >= lsize == sz.
  * when extending the vector, it initializes newly allocated elements
  * with zeros.
+ * the implementation might or might not choose to shrink psize. the api
+ * user should not rely on either behavior.
  */
 #define VEC_RESIZE(ctx, v, sz) _vec_resize(ctx, &v, sizeof(*v.p), sz);
 /*
@@ -39,7 +41,7 @@ __END_EXTERN_C
  */
 #define VEC_PREALLOC(ctx, v, needed)                                          \
         _vec_prealloc(ctx, &v, sizeof(*v.p), needed);
-#define VEC_FREE(ctx, v) _vec_free(ctx, &v)
+#define VEC_FREE(ctx, v) _vec_free(ctx, &v, sizeof(*v.p))
 #define VEC_FOREACH(it, v) ARRAY_FOREACH(it, v.p, v.lsize)
 #define VEC_FOREACH_IDX(i, it, v) for (i = 0, it = v.p; i < v.lsize; i++, it++)
 #define VEC_ELEM(v, idx) (v.p[idx])

--- a/libdyld/dyld.h
+++ b/libdyld/dyld.h
@@ -7,6 +7,7 @@
 #include "vec.h"
 
 struct dyld_object;
+struct mem_context;
 
 struct dyld_options {
         struct import_object *base_import_obj;
@@ -77,17 +78,21 @@ struct dyld {
 #if defined(TOYWASM_ENABLE_DYLD_DLFCN)
         VEC(, struct dyld_dynamic_object) dynobjs;
 #endif
+
+        struct mem_context *mctx;
 };
 
 __BEGIN_EXTERN_C
 
 struct import_object;
+struct mem_context;
 
-void dyld_init(struct dyld *d);
+void dyld_init(struct dyld *d, struct mem_context *mctx);
 void dyld_clear(struct dyld *d);
 int dyld_load(struct dyld *d, const char *filename);
 struct instance *dyld_main_object_instance(struct dyld *d);
 void dyld_options_set_defaults(struct dyld_options *opts);
-int import_object_create_for_dyld(struct dyld *d, struct import_object **impp);
+int import_object_create_for_dyld(struct mem_context *mctx, struct dyld *d,
+                                  struct import_object **impp);
 
 __END_EXTERN_C

--- a/libwasi/wasi.c
+++ b/libwasi/wasi.c
@@ -162,14 +162,16 @@ fail:
 }
 
 int
-wasi_instance_create(struct wasi_instance **instp) NO_THREAD_SAFETY_ANALYSIS
+wasi_instance_create(struct mem_context *mctx,
+                     struct wasi_instance **instp) NO_THREAD_SAFETY_ANALYSIS
 {
         struct wasi_instance *inst;
 
-        inst = zalloc(sizeof(*inst));
+        inst = xzalloc(sizeof(*inst));
         if (inst == NULL) {
                 return ENOMEM;
         }
+        inst->mctx = mctx;
         toywasm_mutex_init(&inst->lock);
         toywasm_cv_init(&inst->cv);
         /* the first three slots are reserved for stdin, stdout, stderr */
@@ -322,9 +324,10 @@ static const struct host_module module_wasi[] = {
 };
 
 int
-import_object_create_for_wasi(struct wasi_instance *wasi,
+import_object_create_for_wasi(struct mem_context *mctx,
+                              struct wasi_instance *wasi,
                               struct import_object **impp)
 {
         return import_object_create_for_host_funcs(
-                module_wasi, ARRAYCOUNT(module_wasi), &wasi->hi, impp);
+                mctx, module_wasi, ARRAYCOUNT(module_wasi), &wasi->hi, impp);
 }

--- a/libwasi/wasi.h
+++ b/libwasi/wasi.h
@@ -2,6 +2,7 @@
 
 struct wasi_instance;
 struct import_object;
+struct mem_context;
 
 __BEGIN_EXTERN_C
 
@@ -15,7 +16,8 @@ __BEGIN_EXTERN_C
  * object. see wasi_threads.h.
  */
 
-int wasi_instance_create(struct wasi_instance **instp);
+int wasi_instance_create(struct mem_context *mctx,
+                         struct wasi_instance **instp);
 void wasi_instance_set_args(struct wasi_instance *inst, int argc,
                             const char *const *argv);
 void wasi_instance_set_environ(struct wasi_instance *inst, int nenvs,
@@ -61,7 +63,8 @@ uint32_t wasi_instance_exit_code(struct wasi_instance *wasi);
  * from the wasi instance. that is, host functions like
  * "wasi_snapshot_preview1:path_open".
  */
-int import_object_create_for_wasi(struct wasi_instance *wasi,
+int import_object_create_for_wasi(struct mem_context *mctx,
+                                  struct wasi_instance *wasi,
                                   struct import_object **impp);
 
 uint32_t wasi_convert_errno(int host_errno);

--- a/libwasi/wasi_fdinfo.c
+++ b/libwasi/wasi_fdinfo.c
@@ -70,7 +70,7 @@ int
 wasi_fdinfo_alloc_prestat(struct wasi_fdinfo **fdinfop)
 {
         struct wasi_fdinfo_prestat *fdinfo_prestat =
-                zalloc(sizeof(*fdinfo_prestat));
+                xzalloc(sizeof(*fdinfo_prestat));
         if (fdinfo_prestat == NULL) {
                 return ENOMEM;
         }

--- a/libwasi/wasi_impl.h
+++ b/libwasi/wasi_impl.h
@@ -60,6 +60,8 @@ struct wasi_instance {
         const char *const *envs;
 
         uint32_t exit_code;
+
+        struct mem_context *mctx;
 };
 
 #define WASI_HOST_FUNC(NAME, TYPE) HOST_FUNC_PREFIX(wasi_, NAME, TYPE)

--- a/libwasi/wasi_table.c
+++ b/libwasi/wasi_table.c
@@ -139,7 +139,7 @@ wasi_table_expand(struct wasi_instance *wasi, enum wasi_table_idx idx,
         if (maxfd < osize) {
                 return 0;
         }
-        int ret = VEC_RESIZE(table->table, maxfd + 1);
+        int ret = VEC_RESIZE(wasi->mctx, table->table, maxfd + 1);
         if (ret != 0) {
                 return ret;
         }
@@ -171,7 +171,7 @@ wasi_table_clear(struct wasi_instance *wasi,
                 }
                 free(fdinfo);
         }
-        VEC_FREE(table->table);
+        VEC_FREE(wasi->mctx, table->table);
 }
 
 int

--- a/libwasi_littlefs/wasi_littlefs_mount.c
+++ b/libwasi_littlefs/wasi_littlefs_mount.c
@@ -102,7 +102,7 @@ wasi_littlefs_mount_file(const char *path, struct wasi_vfs **vfsp)
         struct wasi_vfs_lfs *vfs_lfs = NULL;
         int ret;
 
-        vfs_lfs = zalloc(sizeof(*vfs_lfs));
+        vfs_lfs = xzalloc(sizeof(*vfs_lfs));
         if (vfs_lfs == NULL) {
                 ret = ENOMEM;
                 goto fail;

--- a/libwasi_threads/wasi_threads.h
+++ b/libwasi_threads/wasi_threads.h
@@ -11,7 +11,8 @@ struct trap_info;
 __BEGIN_EXTERN_C
 
 void wasi_threads_instance_destroy(struct wasi_threads_instance *inst);
-int wasi_threads_instance_create(struct wasi_threads_instance **instp);
+int wasi_threads_instance_create(struct mem_context *mctx,
+                                 struct wasi_threads_instance **instp);
 
 /*
  * wasi_threads_instance_set_thread_spawn_args: set wasi-threads parameters
@@ -41,7 +42,8 @@ wasi_threads_setup_exec_context(struct wasi_threads_instance *wasi_threads,
 void wasi_threads_complete_exec(struct wasi_threads_instance *wasi_threads,
                                 const struct trap_info **trapp);
 
-int import_object_create_for_wasi_threads(struct wasi_threads_instance *wasi,
+int import_object_create_for_wasi_threads(struct mem_context *mctx,
+                                          struct wasi_threads_instance *wasi,
                                           struct import_object **impp);
 
 __END_EXTERN_C


### PR DESCRIPTION
todo
* ~~bitmap.h~~
* ~~jump table~~
* ~~type annotation~~
* ~~cellidxes~~
* ~~localchunks~~
* ~~resulttype_alloc~~
* waitlist
* functype_to_string (only used by callgraph example)
* fileio.c
* ~~struct validation_context~~
* ~~add cli options to specify limit~~
* ~~adapt dyld~~
* host functions. libwasi tables have been adapted. maybe other structures? but it's a bit moot as we can't account host resources (eg libc internal consumption) anyway.
* ~~adapt examples~~
* benchmark the overhead
