### PR TITLE
mem_resize: separate to mem_extend and mem_shrink

### DIFF
--- a/lib/decode.c
+++ b/lib/decode.c
@@ -108,7 +108,7 @@ _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
                 goto fail;
         }
         uint32_t total_count = orig_count + vec_count;
-        ret = resize_array(mctx, resultp, elem_size, orig_count, total_count);
+        ret = array_extend(mctx, resultp, elem_size, orig_count, total_count);
         if (ret != 0) {
                 goto fail;
         }
@@ -124,7 +124,7 @@ _read_vec_with_ctx_impl(struct mem_context *mctx, const uint8_t **pp,
                                 }
                         }
                         /* revert the array size */
-                        int ret1 = resize_array(mctx, resultp, elem_size,
+                        int ret1 = array_shrink(mctx, resultp, elem_size,
                                                 total_count, orig_count);
                         assert(ret1 == 0);
                         goto fail;

--- a/lib/exec_insn_subr.c
+++ b/lib/exec_insn_subr.c
@@ -104,7 +104,7 @@ do_trap:
 #endif
                 size_t need = (size_t)last_byte + 1;
                 assert(need > meminst->allocated);
-                void *np = mem_resize(meminst->mctx, meminst->data,
+                void *np = mem_extend(meminst->mctx, meminst->data,
                                       meminst->allocated, need);
                 if (np == NULL) {
                         return ENOMEM;
@@ -348,7 +348,7 @@ table_grow(struct tableinst *t, const struct val *val, uint32_t n)
                 ret = EOVERFLOW;
         } else {
                 size_t oldncells = t->size * csz;
-                ret = ARRAY_RESIZE(t->mctx, t->cells, oldncells, newncells);
+                ret = ARRAY_EXTEND(t->mctx, t->cells, oldncells, newncells);
         }
         if (ret != 0) {
                 return (uint32_t)-1;
@@ -479,7 +479,7 @@ retry:
                         ret = EOVERFLOW;
                 } else {
                         void *np =
-                                mem_resize(mi->mctx, mi->data, mi->allocated,
+                                mem_extend(mi->mctx, mi->data, mi->allocated,
                                            new_size_in_bytes);
                         if (np == NULL) {
                                 ret = ENOMEM;

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -300,7 +300,7 @@ table_instance_create(struct mem_context *mctx, struct tableinst **tip,
                 ret = EOVERFLOW;
                 goto fail;
         }
-        ret = ARRAY_RESIZE(mctx, tinst->cells, 0, ncells);
+        ret = ARRAY_EXTEND(mctx, tinst->cells, 0, ncells);
         if (ret != 0) {
                 goto fail;
         }

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -25,7 +25,9 @@ void *__must_check mem_zalloc(struct mem_context *ctx, size_t sz) __malloc_like
         __alloc_size(2);
 void *__must_check mem_calloc(struct mem_context *ctx, size_t a, size_t b);
 void mem_free(struct mem_context *ctx, void *p, size_t sz);
-void *__must_check mem_resize(struct mem_context *ctx, void *p, size_t oldsz,
+void *__must_check mem_extend(struct mem_context *ctx, void *p, size_t oldsz,
+                              size_t newsz) __malloc_like __alloc_size(4);
+void *__must_check mem_shrink(struct mem_context *ctx, void *p, size_t oldsz,
                               size_t newsz) __malloc_like __alloc_size(4);
 
 __END_EXTERN_C

--- a/lib/util.h
+++ b/lib/util.h
@@ -8,12 +8,15 @@
 void *__must_check xzalloc(size_t sz) __malloc_like __alloc_size(1);
 
 struct mem_context;
-int __must_check resize_array(struct mem_context *ctx, void **p,
+int __must_check array_extend(struct mem_context *ctx, void **p,
+                              size_t elem_size, uint32_t old_elem_count,
+                              uint32_t new_elem_count);
+int __must_check array_shrink(struct mem_context *ctx, void **p,
                               size_t elem_size, uint32_t old_elem_count,
                               uint32_t new_elem_count);
 
-#define ARRAY_RESIZE(ctx, a, osz, sz)                                         \
-        resize_array((ctx), (void **)&(a), sizeof(*a), osz, sz)
+#define ARRAY_EXTEND(ctx, a, osz, sz)                                         \
+        array_extend((ctx), (void **)&(a), sizeof(*a), osz, sz)
 #define ARRAY_FOREACH(p, a, sz) for (p = a; p < a + sz; p++)
 
 #define ZERO(p) memset(p, 0, sizeof(*p))

--- a/lib/validation.c
+++ b/lib/validation.c
@@ -205,7 +205,7 @@ push_ctrlframe(uint32_t pc, enum ctrlframe_op op, uint32_t jumpslot,
                 nslots = 2;
         }
         if (nslots > 0) {
-                ret = resize_array(validation_mctx(ctx), (void **)&ei->jumps,
+                ret = array_extend(validation_mctx(ctx), (void **)&ei->jumps,
                                    sizeof(*ei->jumps), ei->njumps,
                                    ei->njumps + nslots);
                 if (ret != 0) {
@@ -409,7 +409,7 @@ record_type_annotation(struct validation_context *vctx, const uint8_t *p,
                 }
         }
         int ret;
-        ret = resize_array(validation_mctx(vctx), (void **)&an->types,
+        ret = array_extend(validation_mctx(vctx), (void **)&an->types,
                            sizeof(*an->types), an->ntypes, an->ntypes + 1);
         if (ret != 0) {
                 return ret;

--- a/lib/vec.c
+++ b/lib/vec.c
@@ -16,7 +16,7 @@ _vec_resize(struct mem_context *mctx, void *vec, size_t elem_size,
         assert(v->lsize <= v->psize);
         assert((v->psize == 0) == (v->p == NULL));
         if (new_elem_count > v->psize) {
-                ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize,
+                ret = array_extend(mctx, (void **)&v->p, elem_size, v->psize,
                                    new_elem_count);
                 if (ret != 0) {
                         return ret;
@@ -39,7 +39,7 @@ _vec_prealloc(struct mem_context *mctx, void *vec, size_t elem_size,
         int ret;
         uint32_t need = v->lsize + count;
         if (need > v->psize) {
-                ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize,
+                ret = array_extend(mctx, (void **)&v->p, elem_size, v->psize,
                                    need);
                 if (ret != 0) {
                         return ret;
@@ -53,9 +53,9 @@ void
 _vec_free(struct mem_context *mctx, void *vec, size_t elem_size)
 {
         struct _vec *v = vec;
-        int ret = resize_array(mctx, (void **)&v->p, elem_size, v->psize, 0);
+        int ret = array_shrink(mctx, (void **)&v->p, elem_size, v->psize, 0);
         assert(ret == 0);
-        v->p = NULL;
+        assert(v->p == NULL);
         v->lsize = 0;
         v->psize = 0;
 }


### PR DESCRIPTION
in the most callsites, it's obvious which one should be used. there is little reason to leave it to the lower level api, mem_resize to decide which is the case.

while i'm here, fix the resize_array vs ARRAY_RESIZE naming inconsistency as well.

mem_resize -> mem_extend, mem_shrink
resize_array -> array_extend, array_shrink
ARRAY_RESIZE -> ARRAY_EXTEND