### PR TITLE
Fix link to raw values in `startup.md`

### DIFF
--- a/benchmark/startup.md
+++ b/benchmark/startup.md
@@ -19,7 +19,7 @@ print the `-version` message)
   2.2 GHz 6-Core Intel Core i7
   ```
 
-* [Raw values](./startup.txt)
+* [Raw values](./startup.csv)
 
 * Plotted with [plot.py](./plot.py).
 


### PR DESCRIPTION
This fixes the file link to `startup.txt` which got renamed to `startup.csv`.