### PR TITLE
cli: fix --max-memory regression

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -342,7 +342,7 @@ main(int argc, char *const *argv)
         mem_context_init(dyld_mctx);
         mem_context_init(impobj_mctx);
         modules_mctx->parent = mctx;
-        modules_mctx->parent = mctx;
+        instances_mctx->parent = mctx;
         wasi_mctx->parent = mctx;
         dyld_mctx->parent = mctx;
         impobj_mctx->parent = mctx;


### PR DESCRIPTION
the regression was introduced by
commit 217a733089efc18f2a75193552df74de1db0a8ed
("cli: use separate mem contexts for modules and instances")