### PR TITLE
remove warning for debug build

### DIFF
--- a/libwasi/wasi_abi_sock.c
+++ b/libwasi/wasi_abi_sock.c
@@ -68,13 +68,13 @@ wasi_sock_accept(struct exec_context *ctx, struct host_instance *hi,
                 goto fail;
         }
         struct sockaddr_storage ss;
-        struct sockaddr *sa = (void *)&ss;
         socklen_t salen;
 retry:
 #if defined(TOYWASM_OLD_WASI_LIBC)
         errno = ENOSYS;
         hostchildfd = -1;
 #else
+        struct sockaddr *sa = (void *)&ss;
         hostchildfd = accept(hostfd, sa, &salen);
 #endif
         if (hostchildfd < 0) {


### PR DESCRIPTION
sa is only used  when TOYWASM_OLD_WASI_LIBC