### PR TITLE
fix GCC warnings for the target with long uint32_t

### DIFF
--- a/lib/exec.c
+++ b/lib/exec.c
@@ -253,8 +253,8 @@ frame_enter(struct exec_context *ctx, struct instance *inst, uint32_t funcidx,
 #endif
         cells_zero(locals + nparams, nlocals - nparams);
 
-        xlog_trace_insn("frame enter: maxlabels %u maxcells %u", ei->maxlabels,
-                        ei->maxcells);
+        xlog_trace_insn("frame enter: maxlabels %" PRIu32 " maxcells %" PRIu32,
+                        ei->maxlabels, ei->maxcells);
         uint32_t i;
         for (i = 0; i < nlocals; i++) {
                 if (i == nparams) {

--- a/lib/exec_debug.c
+++ b/lib/exec_debug.c
@@ -11,7 +11,7 @@
 
 #define VEC_PRINT_USAGE(name, vec)                                            \
         nbio_printf("%s %" PRIu32 " (%zu bytes)\n", (name), (vec)->psize,     \
-                    (vec)->psize * sizeof(*(vec)->p));
+                    (size_t)(vec)->psize * sizeof(*(vec)->p));
 
 #define STAT_PRINT(name)                                                      \
         nbio_printf("%23s %12" PRIu64 "\n", #name, ctx->stats.name);

--- a/lib/exec_insn_subr.c
+++ b/lib/exec_insn_subr.c
@@ -131,7 +131,7 @@ memory_getptr2(struct exec_context *ctx, uint32_t memidx, uint32_t ptr,
                         " + %08" PRIx32 ", size %" PRIu32
                         ", meminst size %" PRIu32 ", pagesize %" PRIu32,
                         memidx, ptr, offset, size, meminst->size_in_pages,
-                        1 << memtype_page_shift(meminst->type));
+                        memtype_page_size(meminst->type));
                 assert(ret != 0);
         }
         return ret;
@@ -706,7 +706,7 @@ fail:
         }
         memory_atomic_unlock(lock);
         if (ret == 0) {
-                xlog_trace("%s: returning %d result %d", __func__, ret,
+                xlog_trace("%s: returning %d result %" PRIu32, __func__, ret,
                            *resultp);
         } else {
                 xlog_trace("%s: returning %d", __func__, ret);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -245,7 +245,7 @@ read_expr_common(const uint8_t **pp, const uint8_t *ep, struct expr *expr,
 #endif
         xlog_trace("code size %zu, jump table size %zu, max labels %" PRIu32
                    ", cells %" PRIu32,
-                   p - expr->start, ei->njumps * sizeof(*ei->jumps),
+                   p - expr->start, (size_t)ei->njumps * sizeof(*ei->jumps),
                    ei->maxlabels, ei->maxcells);
         validation_context_reuse(vctx);
         return 0;

--- a/lib/host_instance.c
+++ b/lib/host_instance.c
@@ -219,7 +219,7 @@ host_func_getptr2(struct exec_context *ctx, struct meminst *mem, uint32_t ptr,
                         ", size %" PRIu32 ", meminst size %" PRIu32
                         ", pagesize %" PRIu32,
                         ptr, size, mem->size_in_pages,
-                        1 << memtype_page_shift(mem->type));
+                        memtype_page_size(mem->type));
         }
         return ret;
 }

--- a/lib/insn_impl_control.h
+++ b/lib/insn_impl_control.h
@@ -511,7 +511,8 @@ INSN_IMPL(call_indirect)
                         goto fail;
                 }
                 const struct functype *ft = &m->types[typeidx];
-                xlog_trace_insn("call_indirect (table %u type %u) %u %u",
+                xlog_trace_insn("call_indirect (table %" PRIu32
+                                " type %" PRIu32 ") %" PRIu32 " %" PRIu32,
                                 tableidx, typeidx, ft->parameter.ntypes,
                                 ft->result.ntypes);
                 ret = pop_valtypes(&ft->parameter, vctx);

--- a/lib/insn_impl_tailcall.h
+++ b/lib/insn_impl_tailcall.h
@@ -70,7 +70,8 @@ INSN_IMPL(return_call_indirect)
                         goto fail;
                 }
                 const struct functype *ft = &m->types[typeidx];
-                xlog_trace_insn("call_indirect (table %u type %u) %u %u",
+                xlog_trace_insn("call_indirect (table %" PRIu32
+                                " type %" PRIu32 ") %" PRIu32 " %" PRIu32,
                                 tableidx, typeidx, ft->parameter.ntypes,
                                 ft->result.ntypes);
                 ret = pop_valtypes(&ft->parameter, vctx);

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -782,6 +782,6 @@ instance_print_stats(const struct instance *inst)
                             " pages (min/max=%" PRIu32 "/%" PRIu32
                             " pagesize=%" PRIu32 ")\n",
                             i, mi->allocated, mi->size_in_pages, lim->min,
-                            lim->max, 1 << memtype_page_shift(mi->type));
+                            lim->max, memtype_page_size(mi->type));
         }
 }

--- a/lib/module.c
+++ b/lib/module.c
@@ -1637,7 +1637,8 @@ read_code_section(const uint8_t **pp, const uint8_t *ep,
 
         uint32_t i;
         for (i = 0; i < m->nfuncs; i++) {
-                xlog_trace("func nlocals %u", m->funcs[i].localtype.nlocals);
+                xlog_trace("func nlocals %" PRIu32,
+                           m->funcs[i].localtype.nlocals);
         }
 
         *pp = p;
@@ -2214,7 +2215,7 @@ module_load_into(struct module *m, const uint8_t *p, const uint8_t *ep,
                 goto fail;
         }
         if (v != 1) { /* version */
-                report_error(&ctx->report, "wrong version: %u", v);
+                report_error(&ctx->report, "wrong version: %" PRIu32, v);
                 ret = EINVAL;
                 goto fail;
         }

--- a/lib/type.c
+++ b/lib/type.c
@@ -449,3 +449,9 @@ memtype_page_shift(const struct memtype *type)
         return WASM_PAGE_SHIFT;
 #endif
 }
+
+uint32_t
+memtype_page_size(const struct memtype *type)
+{
+        return UINT32_C(1) << memtype_page_shift(type);
+}

--- a/lib/type.h
+++ b/lib/type.h
@@ -733,6 +733,7 @@ void set_name_cstr(struct name *name, const char *cstr);
 void clear_name(struct name *name);
 
 uint32_t memtype_page_shift(const struct memtype *type);
+uint32_t memtype_page_size(const struct memtype *type);
 
 const uint8_t *expr_end(const struct expr *expr);
 

--- a/libwasi/wasi.c
+++ b/libwasi/wasi.c
@@ -151,8 +151,8 @@ wasi_instance_populate_stdio_with_hostfd(struct wasi_instance *inst)
         for (i = 0; i < nfds; i++) {
                 ret = wasi_instance_add_hostfd(inst, i, i);
                 if (ret != 0) {
-                        xlog_error("wasi_instance_add_hostfd failed on fd %d "
-                                   "with %d",
+                        xlog_error("wasi_instance_add_hostfd failed on fd "
+                                   "%" PRIu32 "with %d",
                                    i, ret);
                         goto fail;
                 }

--- a/libwasi/wasi_abi_sock.c
+++ b/libwasi/wasi_abi_sock.c
@@ -63,7 +63,8 @@ wasi_sock_accept(struct exec_context *ctx, struct host_instance *hi,
          * cf. https://www.austingroupbugs.net/view.php?id=411)
          */
         if ((fdflags & ~WASI_FDFLAG_NONBLOCK) != 0) {
-                xlog_error("%s: unsupported fdflags %x", __func__, fdflags);
+                xlog_error("%s: unsupported fdflags %" PRIx32, __func__,
+                           fdflags);
                 ret = ENOTSUP;
                 goto fail;
         }

--- a/libwasi/wasi_host_fdop.c
+++ b/libwasi/wasi_host_fdop.c
@@ -292,8 +292,7 @@ wasi_host_fd_close(struct wasi_fdinfo *fdinfo)
                 ret = close(hostfd);
                 ret = handle_errno(ret);
                 if (ret != 0) {
-                        xlog_trace("failed to close: host fd %" PRIu32
-                                   " with errno %d",
+                        xlog_trace("failed to close: host fd %d with errno %d",
                                    hostfd, ret);
                 }
         }

--- a/libwasi/wasi_path_subr.c
+++ b/libwasi/wasi_path_subr.c
@@ -4,6 +4,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -73,7 +74,7 @@ wasi_copyin_and_convert_path(struct exec_context *ctx,
                 assert(ret > 0);
                 goto fail;
         }
-        xlog_trace("%s: wasifd %d wasmpath %s hostpath %s", __func__,
+        xlog_trace("%s: wasifd %" PRIu32 " wasmpath %s hostpath %s", __func__,
                    dirwasifd, wasmpath, hostpath);
         pi->hostpath = hostpath;
         pi->dirfdinfo = dirfdinfo;

--- a/libwasi_threads/wasi_threads.c
+++ b/libwasi_threads/wasi_threads.c
@@ -521,7 +521,7 @@ wasi_thread_spawn_old(struct exec_context *ctx, struct host_instance *hi,
                 xlog_trace("%s failed with %d", __func__, ret);
         } else {
                 result = tid;
-                xlog_trace("%s succeeded tid %u", __func__, tid);
+                xlog_trace("%s succeeded tid %" PRIu32, __func__, tid);
         }
         HOST_FUNC_RESULT_SET(ft, results, 0, i32, result);
         HOST_FUNC_FREE_CONVERTED_PARAMS();
@@ -549,7 +549,7 @@ wasi_thread_spawn(struct exec_context *ctx, struct host_instance *hi,
                 /* EAGAIN is the only defined error for now. */
                 r.u.error = WASI_THREADS_ERROR_AGAIN;
         } else {
-                xlog_trace("%s succeeded tid %u", __func__, tid);
+                xlog_trace("%s succeeded tid %" PRIu32, __func__, tid);
                 r.is_error = 0;
                 le32_encode(&r.u.tid, tid);
         }


### PR DESCRIPTION
fix GCC warnings for the target with long uint32_t

Note: on some targets, int32_t is a long.
eg. GCC in the recent ESP-IDF has such a configuration.

```shell
    spacetanuki% xtensa-esp32-elf-gcc --version
    xtensa-esp32-elf-gcc (crosstool-NG esp-12.2.0_20230208) 12.2.0
    Copyright (C) 2022 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

    spacetanuki% xtensa-esp32-elf-gcc -dM -E - < /dev/null | grep -E "(SIZE|INT32)_TYPE"
    #define __SIZE_TYPE__ unsigned int
    #define __INT32_TYPE__ long int
    #define __UINT32_TYPE__ long unsigned int
    spacetanuki%
```

references:
https://github.com/apache/nuttx/pull/16022
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/migration-guides/release-5.x/5.0/gcc.html#espressif-toolchain-changes
