### PR TITLE
suppress ubsan complaints on function type mismatches

### DIFF
--- a/cmake/ToywasmConfig.cmake
+++ b/cmake/ToywasmConfig.cmake
@@ -384,7 +384,7 @@ endif()
 list(APPEND SANITIZER_FLAGS "-fno-sanitize=unsigned-integer-overflow")
 # implicit-integer-sign-change: we relies on it for a lot of opcodes.
 list(APPEND SANITIZER_FLAGS "-fno-sanitize=implicit-integer-sign-change")
-# we use NULL+0 in some places. often with VEC_NEXELEM.
+# we use NULL+0 in some places. often with VEC_NEXTELEM.
 list(APPEND SANITIZER_FLAGS "-fno-sanitize=pointer-overflow")
 endif()
 

--- a/lib/leb128.c
+++ b/lib/leb128.c
@@ -151,6 +151,7 @@ read_leb_i32(const uint8_t **pp, const uint8_t *ep, uint32_t *resultp)
         return 0;
 }
 
+WRONG_FUNC_TYPE
 int
 read_leb_u32(const uint8_t **pp, const uint8_t *ep, uint32_t *resultp)
 {

--- a/lib/module.c
+++ b/lib/module.c
@@ -84,6 +84,7 @@ valtype_str(enum valtype vt)
 }
 #endif
 
+WRONG_FUNC_TYPE
 static int
 read_valtype(const uint8_t **pp, const uint8_t *ep, enum valtype *vt)
 {
@@ -232,6 +233,7 @@ clear_resulttype(struct mem_context *mctx, struct resulttype *rt)
 #endif
 }
 
+WRONG_FUNC_TYPE
 static int
 read_functype(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
               struct functype *ft, void *vp)
@@ -271,6 +273,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 void
 clear_functype(struct mem_context *mctx, struct functype *ft)
 {
@@ -411,6 +414,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static int
 read_memtype(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
              struct memtype *mt, void *vctx)
@@ -569,6 +573,7 @@ clear_name(struct name *name)
 {
 }
 
+WRONG_FUNC_TYPE
 static int
 read_tabletype(const uint8_t **pp, const uint8_t *ep, struct tabletype *tt)
 {
@@ -594,6 +599,7 @@ fail:
 }
 
 #if defined(TOYWASM_ENABLE_WASM_EXCEPTION_HANDLING)
+WRONG_FUNC_TYPE
 static int
 read_tagtype(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
              struct tagtype *tag, void *vctx)
@@ -786,6 +792,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static int
 read_import(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
             struct import *im, void *ctx)
@@ -813,6 +820,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_import(struct mem_context *mctx, struct import *im)
 {
@@ -820,6 +828,7 @@ clear_import(struct mem_context *mctx, struct import *im)
         clear_name(&im->name);
 }
 
+WRONG_FUNC_TYPE
 static int
 read_export(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
             struct wasm_export *ex, void *vctx)
@@ -844,6 +853,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_export(struct mem_context *mctx, struct wasm_export *ex)
 {
@@ -942,12 +952,14 @@ clear_expr_exec_info(struct mem_context *mctx, struct expr_exec_info *ei)
 #endif
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_expr(struct mem_context *mctx, struct expr *expr)
 {
         clear_expr_exec_info(mctx, &expr->ei);
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_func(struct mem_context *mctx, struct func *func)
 {
@@ -1079,6 +1091,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static int
 read_func(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
           struct func *func, void *vp)
@@ -1241,6 +1254,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static int
 read_global(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
             struct global *g, void *vctx)
@@ -1266,6 +1280,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_global(struct mem_context *mctx, struct global *g)
 {
@@ -1375,6 +1390,7 @@ read_element_init_expr(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
         return read_const_expr(pp, ep, e, elem->type, ctx->lctx);
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_element(struct mem_context *mctx, struct element *elem)
 {
@@ -1396,6 +1412,7 @@ clear_element(struct mem_context *mctx, struct element *elem)
  * https://webassembly.github.io/spec/core/binary/modules.html#element-section
  * https://webassembly.github.io/spec/core/valid/modules.html#element-segments
  */
+WRONG_FUNC_TYPE
 static int
 read_element(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
              struct element *elem, void *vctx)
@@ -1656,6 +1673,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static int
 read_data(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
           struct data *data, void *vctx)
@@ -1718,6 +1736,7 @@ fail:
         return ret;
 }
 
+WRONG_FUNC_TYPE
 static void
 clear_data(struct mem_context *mctx, struct data *data)
 {
@@ -1777,6 +1796,7 @@ fail:
 }
 
 #if defined(TOYWASM_ENABLE_WASM_EXCEPTION_HANDLING)
+WRONG_FUNC_TYPE
 static void
 clear_tagtype(struct mem_context *mctx, struct tagtype *tag)
 {

--- a/lib/name.c
+++ b/lib/name.c
@@ -50,6 +50,7 @@ struct read_naming_context {
         uint32_t lastidx;
 };
 
+WRONG_FUNC_TYPE
 static int
 read_naming(const uint8_t **pp, const uint8_t *ep, uint32_t idx,
             struct naming *naming, void *vp)

--- a/lib/platform.h
+++ b/lib/platform.h
@@ -160,6 +160,19 @@
 #endif
 #endif /* !defined(__unused) */
 
+/*
+ * Mark a function to be potentially called via a pointer with
+ * a wrong function type. This should not be used because it's
+ * an undefined behavior in C.
+ *
+ * Note: this attribute should be on the callee functions, not the caller.
+ */
+#if defined(__clang__)
+#define WRONG_FUNC_TYPE __attribute__((no_sanitize("function")))
+#else
+#define WRONG_FUNC_TYPE
+#endif
+
 #if __has_builtin(__builtin_add_overflow)
 #define ADD_U32_OVERFLOW(a, b, c) __builtin_add_overflow(a, b, c)
 #else


### PR DESCRIPTION
after updating Xcode to 16.3, it started to complain on
these UDs. (correctly)

as i can imagine no nice way to fix the issue, let's disable
the check for now.

alternativs:

* make these functions use void *.
  i don't like it because it actually loosen type checks.

* make _read_vec_with_ctx_impl a macro.
  it's too large to implement as a macro in my taste.
