### PR TITLE
retire module_find_export_func

### DIFF
--- a/cli/repl.c
+++ b/cli/repl.c
@@ -1212,10 +1212,11 @@ toywasm_repl_invoke(struct repl_state *state, const char *modname,
         assert(inst != NULL);
         assert(module != NULL);
         uint32_t funcidx;
-        ret = module_find_export_func(module, &funcname_name, &funcidx);
+        ret = module_find_export(module, &funcname_name, EXTERNTYPE_FUNC,
+                                 &funcidx);
         if (ret != 0) {
                 /* TODO should print the name w/o unescape */
-                xlog_error("module_find_export_func failed for %s", funcname);
+                xlog_error("module_find_export failed for %s", funcname);
                 goto fail;
         }
         const struct functype *ft = module_functype(module, funcidx);

--- a/examples/run/run.c
+++ b/examples/run/run.c
@@ -67,9 +67,9 @@ main(int argc, char **argv)
         uint32_t funcidx;
         struct name name;
         set_name_cstr(&name, func_name);
-        ret = module_find_export_func(m, &name, &funcidx);
+        ret = module_find_export(m, &name, EXTERNTYPE_FUNC, &funcidx);
         if (ret != 0) {
-                xlog_error("module_find_export_func failed with %d", ret);
+                xlog_error("module_find_export failed with %d", ret);
                 goto fail;
         }
         const struct functype *ft = module_functype(m, funcidx);

--- a/examples/runwasi/runwasi.c
+++ b/examples/runwasi/runwasi.c
@@ -31,9 +31,9 @@ runwasi_module(
          */
         uint32_t funcidx;
         struct name name = NAME_FROM_CSTR_LITERAL("_start");
-        ret = module_find_export_func(m, &name, &funcidx);
+        ret = module_find_export(m, &name, EXTERNTYPE_FUNC, &funcidx);
         if (ret != 0) {
-                xlog_error("module_find_export_func failed with %d", ret);
+                xlog_error("module_find_export failed with %d", ret);
                 goto fail;
         }
         const struct functype *ft = module_functype(m, funcidx);

--- a/lib/module.h
+++ b/lib/module.h
@@ -19,8 +19,6 @@ void module_destroy(struct mem_context *mctx, struct module *m);
  */
 int module_find_export(const struct module *m, const struct name *name,
                        uint32_t type, uint32_t *idxp);
-int module_find_export_func(const struct module *m, const struct name *name,
-                            uint32_t *funcidxp);
 void module_print_stats(const struct module *m);
 
 __END_EXTERN_C

--- a/lib/type.c
+++ b/lib/type.c
@@ -107,13 +107,6 @@ module_find_export(const struct module *m, const struct name *name,
 #endif
 }
 
-int
-module_find_export_func(const struct module *m, const struct name *name,
-                        uint32_t *funcidxp)
-{
-        return module_find_export(m, name, EXTERNTYPE_FUNC, funcidxp);
-}
-
 const struct import *
 module_find_import(const struct module *m, enum externtype type, uint32_t idx)
 {

--- a/libdyld/dyld.c
+++ b/libdyld/dyld.c
@@ -689,7 +689,7 @@ dyld_execute_obj_init_func1(struct dyld_object *obj, const struct name *name)
         struct module *m = obj->module;
         uint32_t funcidx;
         int ret;
-        ret = module_find_export_func(m, name, &funcidx);
+        ret = module_find_export(m, name, EXTERNTYPE_FUNC, &funcidx);
         if (ret != 0) {
                 return ret;
         }

--- a/libwasi_threads/wasi_threads.c
+++ b/libwasi_threads/wasi_threads.c
@@ -190,7 +190,7 @@ wasi_threads_instance_set_thread_spawn_args(
         struct name funcname_name;
         funcname_name.data = funcname;
         funcname_name.nbytes = strlen(funcname);
-        ret = module_find_export_func(m, &funcname_name, &funcidx);
+        ret = module_find_export(m, &funcname_name, EXTERNTYPE_FUNC, &funcidx);
         if (ret != 0) {
                 xlog_trace("%s: start func not found %d", __func__, ret);
                 goto fail;


### PR DESCRIPTION
because it's redundant.

```
module_find_export_func(m, &funcname_name, &funcidx)
```
is an equivalent of
```
module_find_export(m, &funcname_name, EXTERNTYPE_FUNC, &funcidx)
```