### PR TITLE
build-wasm32-wasi.sh: make it easier to build for wasi-threads

### DIFF
--- a/build-wasm32-wasi.sh
+++ b/build-wasm32-wasi.sh
@@ -11,9 +11,13 @@ set -e
 MAJOR=${WASI_SDK_MAJOR:-33}
 MINOR=${WASI_SDK_MINOR:-0}
 WASI_SDK_DIR=${WASI_SDK_DIR:-$(pwd)/.wasi-sdk-${MAJOR}.${MINOR}}
-CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-${WASI_SDK_DIR}/share/cmake/wasi-sdk-p1.cmake}
-if [ ! -e ${WASI_SDK_DIR}/share/cmake/wasi-sdk-p1.cmake ]; then
-    CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-${WASI_SDK_DIR}/share/cmake/wasi-sdk.cmake}
+if [ -n "${BUILD_WASM32_WASI_BUILD_FOR_WASI_THREADS}" ]; then
+    CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-${WASI_SDK_DIR}/share/cmake/wasi-sdk-pthread.cmake}
+else
+    CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-${WASI_SDK_DIR}/share/cmake/wasi-sdk-p1.cmake}
+    if [ ! -e ${WASI_SDK_DIR}/share/cmake/wasi-sdk-p1.cmake ]; then
+        CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE:-${WASI_SDK_DIR}/share/cmake/wasi-sdk.cmake}
+    fi
 fi
 DIST_DIR=.dist
 


### PR DESCRIPTION
eg.
BUILD_WASM32_WASI_BUILD_FOR_WASI_THREADS=1 ./build-wasm32-wasi.sh